### PR TITLE
Fix crash in debug log statements when linking a vde switch to another d...

### DIFF
--- a/gns3/node.py
+++ b/gns3/node.py
@@ -323,6 +323,7 @@ class Node(QtCore.QObject):
             nio_info["remote_file"] = nio.remoteFile()
 
             log.debug("creating {} for {} with local file '{}' and remote file '{}'".format(nio,
+                                                                                            self.name(),
                                                                                             nio.localFile(),
                                                                                             nio.remoteFile()))
             return nio_info
@@ -334,6 +335,7 @@ class Node(QtCore.QObject):
             nio_info["local_file"] = nio.localFile()
 
             log.debug("creating {} for {} with control file '{}' and local file '{}'".format(nio,
+                                                                                             self.name(),
                                                                                              nio.controlFile(),
                                                                                              nio.localFile()))
             return nio_info


### PR DESCRIPTION
After adding a vde interface to a cloud, attempting to link the vde interface with another device GNS3 fails with the traceback shown below.  The problem was a missing argument to the formatter in log.debug() in gns3/node.py.

```
=== GNS3 1.0beta1 traceback on 26 Jul 2014 19:10:20 === 
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/gns3_gui-1.0beta1-py3.4.egg/gns3/graphics_view.py", line 480, in mousePressEvent
    self._userNodeLinking(event, item)
  File "/usr/local/lib/python3.4/dist-packages/gns3_gui-1.0beta1-py3.4.egg/gns3/graphics_view.py", line 427, in _userNodeLinking
    self.addLink(source_item.node(), source_port, destination_item.node(), destination_port)
  File "/usr/local/lib/python3.4/dist-packages/gns3_gui-1.0beta1-py3.4.egg/gns3/graphics_view.py", line 273, in addLink
    link = Link(source_node, source_port, destination_node, destination_port)
  File "/usr/local/lib/python3.4/dist-packages/gns3_gui-1.0beta1-py3.4.egg/gns3/link.py", line 109, in __init__
    self._destination_node.addNIO(self._destination_port, self._destination_nio)
  File "/usr/local/lib/python3.4/dist-packages/gns3_gui-1.0beta1-py3.4.egg/gns3/modules/dynamips/nodes/router.py", line 702, in addNIO
    params["nio"] = self.getNIOInfo(nio)
  File "/usr/local/lib/python3.4/dist-packages/gns3_gui-1.0beta1-py3.4.egg/gns3/node.py", line 338, in getNIOInfo
    nio.localFile()))
IndexError: tuple index out of range
```
