### PR TITLE
Fix to include all files.

### DIFF
--- a/gns3/modules/iou/pages/iou_device_preferences_page.py
+++ b/gns3/modules/iou/pages/iou_device_preferences_page.py
@@ -191,7 +191,7 @@ class IOUDevicePreferencesPage(QtGui.QWidget, Ui_IOUDevicePreferencesPageWidget)
         path, _ = QtGui.QFileDialog.getOpenFileNameAndFilter(parent,
                                                              "Select an IOU image",
                                                              destination_directory,
-                                                             "All files (*.*);;IOU image (*.bin *.image)",
+                                                             "All files (*)",
                                                              "IOU image (*.bin *.image)")
 
         if not path:


### PR DESCRIPTION
Extension of the file is not mandatory. All files filter should be "_" and not "_.*"
