### PR TITLE
Validate the Idle-PC value and display an error if invalid

### DIFF
--- a/gns3/modules/dynamips/dialogs/ios_router_wizard.py
+++ b/gns3/modules/dynamips/dialogs/ios_router_wizard.py
@@ -77,6 +77,14 @@ class IOSRouterWizard(QtGui.QWizard, Ui_IOSRouterWizard):
         self.uiPlatformComboBox.currentIndexChanged[str].connect(self._platformChangedSlot)
         self.uiPlatformComboBox.addItems(list(PLATFORMS_DEFAULT_RAM.keys()))
 
+        # Validate the Idle PC value
+        self._idle_valid = False
+        idle_pc_rgx = QtCore.QRegExp("^(0x[0-9a-fA-F]+)?$")
+        validator = QtGui.QRegExpValidator(idle_pc_rgx)
+        self.uiIdlepcLineEdit.setValidator(validator)
+        self.uiIdlepcLineEdit.textChanged.connect(self._idlePCValidateSlot)
+        self.uiIdlepcLineEdit.textChanged.emit(self.uiIdlepcLineEdit.text())
+
         #FIXME: hide because of issue on Windows.
         self.uiTestIOSImagePushButton.hide()
 
@@ -161,6 +169,24 @@ class IOSRouterWizard(QtGui.QWizard, Ui_IOSRouterWizard):
             RunInTerminal(command)
         except OSError as e:
             QtGui.QMessageBox.critical(self, "IOS image", "Could not test the IOS image: {}".format(e))
+
+    def _idlePCValidateSlot(self):
+        """
+        Slot to validate the entered Idle-PC Value
+        """
+        sender = self.sender()
+        validator = sender.validator()
+        state = validator.validate(sender.text(), 0)[0]
+        if state == QtGui.QValidator.Acceptable:
+            color = '#A2C964'  # green
+            self._idle_valid = True
+        elif state == QtGui.QValidator.Intermediate:
+            color = '#fff79a'  # yellow
+            self._idle_valid = False
+        else:
+            color = '#f6989d'  # red
+            self._idle_valid = False
+        sender.setStyleSheet('QLineEdit { background-color: %s }' % color)
 
     def _idlePCFinderSlot(self):
         """
@@ -326,7 +352,7 @@ class IOSRouterWizard(QtGui.QWizard, Ui_IOSRouterWizard):
 
     def validateCurrentPage(self):
         """
-        Validates the IOS name.
+        Validates the IOS name and checks validation state for Idle-PC value
         """
 
         if self.currentPage() == self.uiNamePlatformWizardPage:
@@ -335,6 +361,11 @@ class IOSRouterWizard(QtGui.QWizard, Ui_IOSRouterWizard):
                 if ios_router["name"] == name:
                     QtGui.QMessageBox.critical(self, "Name", "{} is already used, please choose another name".format(name))
                     return False
+        elif self.currentPage() == self.uiIdlePCWizardPage:
+            if not self._idle_valid:
+                idle_pc = self.uiIdlepcLineEdit.text()
+                QtGui.QMessageBox.critical(self, "Idle-PC", "{} is not a valid Idle-PC value ".format(idle_pc))
+                return False
         return True
 
 


### PR DESCRIPTION
Validate the Idle-PC value entered in the settings and display an error if not valid.

https://community.gns3.com/message/6546#6546
https://community.gns3.com/thread/4607

This is performing a simple validation using the same regex which is used by the server code.

```
^(0x[0-9a-fA-F]+)?$
```
