### PR TITLE
Run VirtualBox as another user

### DIFF
--- a/gns3/modules/virtualbox/__init__.py
+++ b/gns3/modules/virtualbox/__init__.py
@@ -398,6 +398,7 @@ class VirtualBox(Module):
         params = {}
         if server.isLocal():
             params["vboxmanage_path"] = self._settings["vboxmanage_path"]
+            params["vbox_user"] = self._settings["vbox_user"]
         server.send_message("virtualbox.vm_list", params, callback)
 
     def getVirtualBoxVMList(self):

--- a/gns3/modules/virtualbox/pages/virtualbox_preferences_page.py
+++ b/gns3/modules/virtualbox/pages/virtualbox_preferences_page.py
@@ -85,6 +85,7 @@ class VirtualBoxPreferencesPage(QtGui.QWidget, Ui_VirtualBoxPreferencesPageWidge
         """
 
         self.uiVboxManagePathLineEdit.setText(settings["vboxmanage_path"])
+        self.uiVboxManageUserLineEdit.setText(settings["vbox_user"])
         self.uiUseLocalServercheckBox.setChecked(settings["use_local_server"])
         self.uiConsoleStartPortSpinBox.setValue(settings["console_start_port_range"])
         self.uiConsoleEndPortSpinBox.setValue(settings["console_end_port_range"])
@@ -126,6 +127,7 @@ class VirtualBoxPreferencesPage(QtGui.QWidget, Ui_VirtualBoxPreferencesPageWidge
 
         new_settings = {}
         new_settings["vboxmanage_path"] = self.uiVboxManagePathLineEdit.text()
+        new_settings["vbox_user"] = self.uiVboxManageUserLineEdit.text()
         new_settings["use_local_server"] = self.uiUseLocalServercheckBox.isChecked()
         new_settings["console_start_port_range"] = self.uiConsoleStartPortSpinBox.value()
         new_settings["console_end_port_range"] = self.uiConsoleEndPortSpinBox.value()

--- a/gns3/modules/virtualbox/settings.py
+++ b/gns3/modules/virtualbox/settings.py
@@ -48,6 +48,7 @@ else:
 
 VBOX_SETTINGS = {
     "vboxmanage_path": DEFAULT_VBOXMANAGE_PATH,
+    "vbox_user": "",
     "console_start_port_range": 3501,
     "console_end_port_range": 4000,
     "udp_start_port_range": 35001,
@@ -57,6 +58,7 @@ VBOX_SETTINGS = {
 
 VBOX_SETTING_TYPES = {
     "vboxmanage_path": str,
+    "vbox_user": str,
     "console_start_port_range": int,
     "console_end_port_range": int,
     "udp_start_port_range": int,

--- a/gns3/modules/virtualbox/ui/virtualbox_preferences_page.ui
+++ b/gns3/modules/virtualbox/ui/virtualbox_preferences_page.ui
@@ -51,7 +51,17 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0" colspan="2">
+       <item row="5" column="0">
+        <widget class="QLabel" name="uiVboxManageUserLabel">
+         <property name="text">
+          <string>Run VirtualBox as another user (GNS3 running as Linux root):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLineEdit" name="uiVboxManageUserLineEdit"/>
+       </item>
+       <item row="7" column="0" colspan="2">
         <spacer name="spacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/gns3/modules/virtualbox/ui/virtualbox_preferences_page_ui.py
+++ b/gns3/modules/virtualbox/ui/virtualbox_preferences_page_ui.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/grossmj/PycharmProjects/gns3-gui/gns3/modules/virtualbox/ui/virtualbox_preferences_page.ui'
+# Form implementation generated from reading ui file 'virtualbox_preferences_page.ui'
 #
-# Created: Thu Oct 30 17:14:33 2014
+# Created: Fri Dec  5 22:50:01 2014
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -49,8 +49,14 @@ class Ui_VirtualBoxPreferencesPageWidget(object):
         self.uiVboxManagePathToolButton.setObjectName(_fromUtf8("uiVboxManagePathToolButton"))
         self.horizontalLayout_5.addWidget(self.uiVboxManagePathToolButton)
         self.gridLayout.addLayout(self.horizontalLayout_5, 3, 0, 1, 2)
+        self.uiVboxManageUserLabel = QtGui.QLabel(self.uiGeneralSettingsTabWidget)
+        self.uiVboxManageUserLabel.setObjectName(_fromUtf8("uiVboxManageUserLabel"))
+        self.gridLayout.addWidget(self.uiVboxManageUserLabel, 5, 0, 1, 1)
+        self.uiVboxManageUserLineEdit = QtGui.QLineEdit(self.uiGeneralSettingsTabWidget)
+        self.uiVboxManageUserLineEdit.setObjectName(_fromUtf8("uiVboxManageUserLineEdit"))
+        self.gridLayout.addWidget(self.uiVboxManageUserLineEdit, 6, 0, 1, 1)
         spacerItem = QtGui.QSpacerItem(390, 193, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
-        self.gridLayout.addItem(spacerItem, 5, 0, 1, 2)
+        self.gridLayout.addItem(spacerItem, 7, 0, 1, 2)
         self.uiTabWidget.addTab(self.uiGeneralSettingsTabWidget, _fromUtf8(""))
         self.uiServerSettingsTabWidget = QtGui.QWidget()
         self.uiServerSettingsTabWidget.setObjectName(_fromUtf8("uiServerSettingsTabWidget"))
@@ -143,6 +149,7 @@ class Ui_VirtualBoxPreferencesPageWidget(object):
         VirtualBoxPreferencesPageWidget.setWindowTitle(_translate("VirtualBoxPreferencesPageWidget", "VirtualBox", None))
         self.uiVboxManagePathLabel.setText(_translate("VirtualBoxPreferencesPageWidget", "Path to VBoxManage:", None))
         self.uiVboxManagePathToolButton.setText(_translate("VirtualBoxPreferencesPageWidget", "&Browse...", None))
+        self.uiVboxManageUserLabel.setText(_translate("VirtualBoxPreferencesPageWidget", "Run VirtualBox as another user (GNS3 running as Linux root):", None))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.uiGeneralSettingsTabWidget), _translate("VirtualBoxPreferencesPageWidget", "General settings", None))
         self.uiUseLocalServercheckBox.setText(_translate("VirtualBoxPreferencesPageWidget", "Always use the local server", None))
         self.uiRemoteServersGroupBox.setTitle(_translate("VirtualBoxPreferencesPageWidget", "Remote servers", None))


### PR DESCRIPTION
This code change allowed me to have VirtualBox VMs and a Cloud device with Internet in GNS3 network at the same time.
(Tested only on Ubuntu Linux)

I ran GNS3 as a root user (required to configure Cloud devices to use my real PC's network cards):
> sudo gns3server (in one terminal window)
> sudo gns3 (in another terminal window)
But with GNS3 running as root, I could not add my VirtualBox non-root VMs to GNS3, because they did not show up in GNS3 VMs list.

To solve this problem, I made the changes to GNS3 server and GNS3 GUI code adding the following new setting to GNS3:

Edit -> Preferences... -> VirtualBox -> General -> General settings -> "Run VirtualBox as another user (GNS3 running as Linux root)"

By default, this field is empty, and when it is empty GNS3 runs as usual, as if there were no code changes at all.
But if I input a non-empty user name and press Apply, all subsequent VirtualBox operations are performed in the name of this user, not the user who is currently running GNS3.

Now I can run GNS3 as Linux root, setup GNS3 to run VirtualBox as the user who owns the VMs, and add these VMs to GNS3 network.

Dmitry
shmygov@rambler.ru
