### PR TITLE
Fix ASA devices in qemu

### DIFF
--- a/gns3/modules/qemu/pages/qemu_vm_preferences_page.py
+++ b/gns3/modules/qemu/pages/qemu_vm_preferences_page.py
@@ -194,6 +194,17 @@ class QemuVMPreferencesPage(QtGui.QWidget, Ui_QemuVMPreferencesPageWidget):
                 _, filename = ntpath.split(src)
                 dst = "images/qemu/{}".format(filename)
                 uploads.append((src, dst))
+            src = qemu_vm.get("initrd", None)
+            if src:
+                _, filename = ntpath.split(src)
+                dst = "images/qemu/{}".format(filename)
+                uploads.append((src, dst))
+
+            src = qemu_vm.get("kernel_image", None)
+            if src:
+                _, filename = ntpath.split(src)
+                dst = "images/qemu/{}".format(filename)
+                uploads.append((src, dst))
 
             upload_thread = UploadFilesThread(self, MainWindow.instance().cloudSettings(), uploads)
             upload_thread.completed.connect(self._imageUploadComplete)

--- a/gns3/pages/cloud_preferences_page.py
+++ b/gns3/pages/cloud_preferences_page.py
@@ -57,7 +57,7 @@ class CloudPreferencesPage(QtGui.QWidget, Ui_CloudPreferencesPageWidget):
         return self.uiRememberAPIKeyRadioButton.isChecked()
 
     def _terms_accepted(self):
-        return self.uiTermsCheckBox.checkState() == QtCore.Qt.Qt.Checked
+        return self.uiTermsCheckBox.checkState() == QtCore.Qt.Checked
 
     def _validate(self):
         """


### PR DESCRIPTION
ASA devices now work in the cloud.  Previously it was broken because the kernel and initrd were not being uploaded to Cloud Files.
