### PR TITLE
Jungle News Feed Exit + Toggle in Docks Menu

### DIFF
--- a/gns3/main_window.py
+++ b/gns3/main_window.py
@@ -135,6 +135,8 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
         self.uiDocksMenu.addAction(self.uiTopologySummaryDockWidget.toggleViewAction())
         self.uiDocksMenu.addAction(self.uiConsoleDockWidget.toggleViewAction())
         self.uiDocksMenu.addAction(self.uiNodesDockWidget.toggleViewAction())
+	# toggle for the Jungle News Widget
+        self.uiDocksMenu.addAction(self._uiNewsDockWidget.toggleViewAction())
         if ENABLE_CLOUD:
             self.uiDocksMenu.addAction(self.uiCloudInspectorDockWidget.toggleViewAction())
 

--- a/gns3/news_dock_widget.py
+++ b/gns3/news_dock_widget.py
@@ -72,8 +72,7 @@ class NewsDockWidget(QtGui.QDockWidget, Ui_NewsDockWidget):
 
         :param event: closeEvent instance.
         """
-
-        event.ignore()
+        event.accept()
 
     def _refreshSlot(self):
         """

--- a/gns3/ui/news_dock_widget.ui
+++ b/gns3/ui/news_dock_widget.ui
@@ -14,7 +14,7 @@
    <bool>false</bool>
   </property>
   <property name="features">
-   <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   <set>QDockWidget::AllDockWidgetFeatures</set>
   </property>
   <property name="allowedAreas">
    <set>Qt::AllDockWidgetAreas</set>
@@ -43,7 +43,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QWebView" name="uiWebView" native="true">
+     <widget class="QWebView" name="uiWebView">
       <property name="minimumSize">
        <size>
         <width>200</width>
@@ -56,9 +56,9 @@
         <height>200</height>
        </size>
       </property>
-      <property name="url" stdset="0">
+      <property name="url">
        <url>
-        <string/>
+        <string>about:blank</string>
        </url>
       </property>
      </widget>

--- a/gns3/ui/news_dock_widget_ui.py
+++ b/gns3/ui/news_dock_widget_ui.py
@@ -28,7 +28,7 @@ class Ui_NewsDockWidget(object):
         NewsDockWidget.setObjectName(_fromUtf8("NewsDockWidget"))
         NewsDockWidget.resize(203, 225)
         NewsDockWidget.setFloating(False)
-        NewsDockWidget.setFeatures(QtGui.QDockWidget.DockWidgetFloatable|QtGui.QDockWidget.DockWidgetMovable)
+        NewsDockWidget.setFeatures(QtGui.QDockWidget.AllDockWidgetFeatures)
         NewsDockWidget.setAllowedAreas(QtCore.Qt.AllDockWidgetAreas)
         self.dockWidgetContents = QtGui.QWidget()
         self.dockWidgetContents.setObjectName(_fromUtf8("dockWidgetContents"))


### PR DESCRIPTION
Hey,

This pull request is to add the Exit to the Jungle News Feed and to be able to toggle it on and off in the docks menu.

I doubt you'll want to have this in your version of the code ( I think its a design choice ), but I thought I'd offer.

Let me know what you think!
:smile:  
