### PR TITLE
Add GNS3 Converter version to console

### DIFF
--- a/gns3/console_cmd.py
+++ b/gns3/console_cmd.py
@@ -28,6 +28,7 @@ import json
 from .qt import QtCore
 from .node import Node
 from .version import __version__
+from gns3converter import __version__ as gns3converter_version
 
 
 class ConsoleCmd(cmd.Cmd):
@@ -45,6 +46,7 @@ class ConsoleCmd(cmd.Cmd):
         if hasattr(sys, "frozen"):
             compiled = "(compiled)"
         print("GNS3 version is {} {}".format(__version__, compiled))
+        print("GNS3 Converter version is {}".format(gns3converter_version))
         print("Python version is {}.{}.{} ({}-bit) with {} encoding".format(sys.version_info[0],
                                                                             sys.version_info[1],
                                                                             sys.version_info[2],

--- a/gns3/version.py
+++ b/gns3/version.py
@@ -25,5 +25,5 @@ or negative for a release candidate or beta (after the base version
 number has been incremented)
 """
 
-__version__ = "1.2.3"
+__version__ = "1.2.4.dev1"
 __version_info__ = (1, 2, 3, 0)


### PR DESCRIPTION
Having the GNS3 converter version available in the console will be useful to identify when an issue lies with a particular converter version