### PR TITLE
Windows readme + requirements ">=" instead of "=="

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,23 @@ Finally these commands will install the GUI as well as the rest of the dependenc
 Windows
 -------
 
-Please use our all-in-one installer.
+Please use our `all-in-one installer <https://community.gns3.com/community/software/download>`_ to install the stable build.
+
+If you install via source you need to first install:
+
+- Python (3.3 or above) - https://www.python.org/downloads/windows/
+- Pywin32 - https://sourceforge.net/projects/pywin32/
+- Qt5 - http://www.qt.io/download-open-source/
+- PyQt5 - http://www.riverbankcomputing.com/software/pyqt/download5
+- PyCrypto (which if you compile from source, requires Visual Studio 2010 with GMP or MPIR libraries)
+
+And finally, call
+
+.. code:: bash
+
+   python setup.py install
+
+to install the remaining dependencies.
 
 Mac OS X
 --------
@@ -90,7 +106,7 @@ Or follow this `HOWTO that uses MacPorts <http://binarynature.blogspot.ca/2014/0
 Developement
 -------------
 
-If you want to update the interface modify the .ui files using QT tools. And:
+If you want to update the interface, modify the .ui files using QT tools. And:
 
 .. code:: bash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-apache-libcloud==0.16.0
-paramiko==1.15.1
-requests==2.4.3
-raven==5.2.0
-rsa==3.1.4
+apache-libcloud>=0.16.0
+paramiko>=1.15.1
+requests>=2.4.3
+raven>=5.2.0
+rsa>=3.1.4


### PR DESCRIPTION
I've updated the readme with some of my experiences in trying to get GNS3 to compile from source on Windows. The instructions aren't fully complete, as I installed PyCrypto from a binary that I stumbled upon, and even its author isn't sure how he compiled it "back in the day" (see [here](https://github.com/axper/python3-pycrypto-windows-installer/issues/1#issuecomment-98202541)).

I've also modified the requirements.txt to reflect the setup.py state.