### PR TITLE
CTRL+Wheel fix

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -521,9 +521,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
         :param: QWheelEvent instance
         """
 
-        if event.modifiers() == QtCore.Qt.ControlModifier and event.orientation() == QtCore.Qt.Vertical:
-            # CTRL is pressed then use the mouse wheel to zoom in or out.
-            self.scaleView(pow(2.0, event.delta() / 240.0))
+        if event.modifiers() == QtCore.Qt.ControlModifier:
+            # event.delta() added for Qt4 compatibility
+            delta = event.angleDelta() if hasattr(event, 'angleDelta') else event.delta()
+            if not delta == None and delta.x() == 0:
+                # CTRL is pressed then use the mouse wheel to zoom in or out.
+                self.scaleView(pow(2.0, delta.y() / 240.0))
         else:
             super().wheelEvent(event)
 


### PR DESCRIPTION
Zooming with the mouse wheel is broken with Qt5, due to Qt API changes.

This fix intentionally includes a check for the new method before applying it, falling back to the old, in order to make the zoom work in both Qt4 and Qt5.

Once GNS3 migrates fully to Qt5 (read: when the "import" patches become unnecessary), the check can be easily removed. In the meantime, this change should be pack portable to "master" too (though I've tested only with Qt5...).