### PR TITLE
Hide device list in config dialog when only one device is selected

### DIFF
--- a/gns3/dialogs/node_configurator_dialog.py
+++ b/gns3/dialogs/node_configurator_dialog.py
@@ -53,8 +53,8 @@ class NodeConfiguratorDialog(QtWidgets.QDialog, Ui_NodeConfiguratorDialog):
         self.uiEmptyPageWidget = self.uiConfigStackedWidget.findChildren(QtWidgets.QWidget, "uiEmptyPageWidget")[0]
         self.uiConfigStackedWidget.setCurrentWidget(self.uiEmptyPageWidget)
 
-        self._loadNodeItems()
         self.splitter.setSizes([250, 600])
+        self._loadNodeItems()
 
         self.uiNodesTreeWidget.itemClicked.connect(self.showConfigurationPageSlot)
         HTTPClient.setProgressCallback(Progress(self, min_duration=0))
@@ -85,6 +85,13 @@ class NodeConfiguratorDialog(QtWidgets.QDialog, Ui_NodeConfiguratorDialog):
 
         # sort the tree
         self.uiNodesTreeWidget.sortByColumn(0, QtCore.Qt.AscendingOrder)
+
+        if len(self._node_items) == 1:
+            parent = " {} group".format(str(node_item.node()))
+            item = self._parent_items[parent].child(0);
+            item.setSelected(True)
+            self.showConfigurationPageSlot(item, 0)
+            self.splitter.setSizes([0, 600])
 
     def showConfigurationPageSlot(self, item, column):
         """


### PR DESCRIPTION
This one has been a minor annoyance to me ever since I first saw GNS3... I quickly realized the device list is useful when multiple nodes are configured at the same time, but it's overkill for a single device, and ultimately makes configurations cumbersome for newcomers (who tend to configure devices one by one, until they figure the whole thing out...).

I was trying to completely remove it in that case, or at least disable a resize of the splitter when the size is 0, but that requires too much refactoring for too little benefit, so this PR does the next best thing - the device list is simply hidden by default when there's only one device selected. Users can still pull it up by dragging the splitter from the left, and the list is there by default if more than one device is selected.