### PR TITLE
Allow alpha channel for text color

### DIFF
--- a/gns3/dialogs/text_editor_dialog.py
+++ b/gns3/dialogs/text_editor_dialog.py
@@ -24,7 +24,6 @@ from ..ui.text_editor_dialog_ui import Ui_TextEditorDialog
 
 
 class TextEditorDialog(QtWidgets.QDialog, Ui_TextEditorDialog):
-
     """
     Text editor dialog.
 
@@ -44,12 +43,10 @@ class TextEditorDialog(QtWidgets.QDialog, Ui_TextEditorDialog):
 
         # use the first item in the list as the model
         first_item = items[0]
-        self._color = first_item.defaultTextColor()
+        self._setColor(first_item.defaultTextColor())
         self.uiRotationSpinBox.setValue(first_item.rotation())
-        self.uiColorPushButton.setStyleSheet("background-color: {}".format(self._color.name()))
         self.uiPlainTextEdit.setPlainText(first_item.toPlainText())
         self.uiPlainTextEdit.setFont(first_item.font())
-        self.uiPlainTextEdit.setStyleSheet("color : {}".format(self._color.name()))
 
         if not first_item.editable():
             self.uiPlainTextEdit.setTextInteractionFlags(QtCore.Qt.NoTextInteraction)
@@ -57,6 +54,17 @@ class TextEditorDialog(QtWidgets.QDialog, Ui_TextEditorDialog):
         if len(self._items) == 1:
             self.uiApplyTextToAllItemsCheckBox.setChecked(True)
             self.uiApplyTextToAllItemsCheckBox.hide()
+
+    def _setColor(self, color):
+        self._color = color
+        self.uiColorPushButton.setStyleSheet("background-color: rgba({}, {}, {}, {});".format(color.red(),
+                                                                                              color.green(),
+                                                                                              color.blue(),
+                                                                                              color.alpha()))
+        self.uiPlainTextEdit.setStyleSheet("color: rgba({}, {}, {}, {});".format(color.red(),
+                                                                                 color.green(),
+                                                                                 color.blue(),
+                                                                                 color.alpha()))
 
     def _setFontSlot(self):
         """
@@ -72,11 +80,9 @@ class TextEditorDialog(QtWidgets.QDialog, Ui_TextEditorDialog):
         Slot to select the color.
         """
 
-        color = QtWidgets.QColorDialog.getColor(self._color, self)
+        color = QtWidgets.QColorDialog.getColor(self._color, self, None, QtWidgets.QColorDialog.ShowAlphaChannel)
         if color.isValid():
-            self._color = color
-            self.uiColorPushButton.setStyleSheet("background-color: {}".format(self._color.name()))
-            self.uiPlainTextEdit.setStyleSheet("color : {}".format(self._color.name()))
+            self._setColor(color)
 
     def _applyPreferencesSlot(self):
         """

--- a/gns3/items/note_item.py
+++ b/gns3/items/note_item.py
@@ -23,7 +23,6 @@ from ..qt import QtCore, QtWidgets, QtGui
 
 
 class NoteItem(QtWidgets.QGraphicsTextItem):
-
     """
     Text note for the QGraphicsView.
 
@@ -37,6 +36,7 @@ class NoteItem(QtWidgets.QGraphicsTextItem):
         super().__init__(parent)
 
         from ..main_window import MainWindow
+
         main_window = MainWindow.instance()
         view_settings = main_window.uiGraphicsView.settings()
         qt_font = QtGui.QFont()
@@ -59,6 +59,7 @@ class NoteItem(QtWidgets.QGraphicsTextItem):
 
         self.scene().removeItem(self)
         from ..topology import Topology
+
         Topology.instance().removeNote(self)
 
     def editable(self):
@@ -198,7 +199,7 @@ class NoteItem(QtWidgets.QGraphicsTextItem):
                      "y": self.y()}
 
         note_info["font"] = self.font().toString()
-        note_info["color"] = self.defaultTextColor().name()
+        note_info["color"] = self.defaultTextColor().name(QtGui.QColor.HexArgb)
         if self.rotation() != 0:
             note_info["rotation"] = self.rotation()
         if self.zValue() != 2:


### PR DESCRIPTION
The title says it all.

I mean "Why not?".

The only sort of issue is that transparent text, just as white text currently, is effectively invisible in the settings dialog... <del>Should the background perhaps also be modified to always be the inverse color? The only color that would possibly be invisible that way would be rgb(127, 127, 127).</del> On second thought, one can always highlight the text if they're unsure, and anyway, it's better if one first writes the text, and only then modifies the color.