### PR TITLE
Made Qemu image wizard text agnostic

### DIFF
--- a/gns3/modules/qemu/ui/qemu_image_wizard.ui
+++ b/gns3/modules/qemu/ui/qemu_image_wizard.ui
@@ -59,7 +59,7 @@
           <string>Qcow2 is the current Qemu format, supporting many special features.</string>
          </property>
          <property name="text">
-          <string>Qcow2</string>
+          <string notr="true">Qcow2</string>
          </property>
          <attribute name="buttonGroup">
           <string notr="true">uiFormatRadios</string>
@@ -72,7 +72,7 @@
           <string>Qcow is a legacy Qemu format that is also supported by VirtualBox.</string>
          </property>
          <property name="text">
-          <string>Qcow</string>
+          <string notr="true">Qcow</string>
          </property>
          <attribute name="buttonGroup">
           <string notr="true">uiFormatRadios</string>
@@ -80,13 +80,13 @@
         </widget>
        </item>
        <item>
-        <widget class="QRadioButton" name="uiFormatVpcRadio">
+        <widget class="QRadioButton" name="uiFormatVhdRadio">
          <property name="toolTip">
           <string>VHD is the format used by Microsoft VirtualPC, and is also supported by Qemu and VirtualBox.
 On Windows 7 and above, it can be mounted on the host PC.</string>
          </property>
          <property name="text">
-          <string>VHD</string>
+          <string notr="true">VHD</string>
          </property>
          <attribute name="buttonGroup">
           <string notr="true">uiFormatRadios</string>
@@ -99,7 +99,7 @@ On Windows 7 and above, it can be mounted on the host PC.</string>
           <string>VDI is the native format of VirtualBox</string>
          </property>
          <property name="text">
-          <string>VDI</string>
+          <string notr="true">VDI</string>
          </property>
          <attribute name="buttonGroup">
           <string notr="true">uiFormatRadios</string>
@@ -112,7 +112,7 @@ On Windows 7 and above, it can be mounted on the host PC.</string>
           <string>VMDK is the native format for VMware and is also supported by Qemu and VirtualBox.</string>
          </property>
          <property name="text">
-          <string>VMDK</string>
+          <string notr="true">VMDK</string>
          </property>
          <attribute name="buttonGroup">
           <string notr="true">uiFormatRadios</string>
@@ -795,10 +795,10 @@ Free space will be zero filled.</string>
  </connections>
  <buttongroups>
   <buttongroup name="uiVmdkSizeModeRadios"/>
+  <buttongroup name="uiVhdSizeModeRadios"/>
   <buttongroup name="uiQcow2PreallocationRadios"/>
+  <buttongroup name="uiVdiSizeModeRadios"/>
   <buttongroup name="uiVmdkAdapterRadios"/>
   <buttongroup name="uiFormatRadios"/>
-  <buttongroup name="uiVdiSizeModeRadios"/>
-  <buttongroup name="uiVhdSizeModeRadios"/>
  </buttongroups>
 </ui>

--- a/gns3/modules/qemu/ui/qemu_image_wizard_ui.py
+++ b/gns3/modules/qemu/ui/qemu_image_wizard_ui.py
@@ -9,9 +9,7 @@
 import gns3.qt
 from gns3.qt import QtCore, QtGui, QtWidgets
 
-
-class Ui_QemuImageWizard:
-
+class Ui_QemuImageWizard(object):
     def setupUi(self, QemuImageWizard):
         QemuImageWizard.setObjectName("QemuImageWizard")
         QemuImageWizard.resize(420, 300)
@@ -37,24 +35,29 @@ class Ui_QemuImageWizard:
         self.verticalLayout = QtWidgets.QVBoxLayout(self.uiFormatFrame)
         self.verticalLayout.setObjectName("verticalLayout")
         self.uiFormatQcow2Radio = QtWidgets.QRadioButton(self.uiFormatFrame)
+        self.uiFormatQcow2Radio.setText("Qcow2")
         self.uiFormatQcow2Radio.setObjectName("uiFormatQcow2Radio")
         self.uiFormatRadios = QtWidgets.QButtonGroup(QemuImageWizard)
         self.uiFormatRadios.setObjectName("uiFormatRadios")
         self.uiFormatRadios.addButton(self.uiFormatQcow2Radio)
         self.verticalLayout.addWidget(self.uiFormatQcow2Radio)
         self.uiFormatQcowRadio = QtWidgets.QRadioButton(self.uiFormatFrame)
+        self.uiFormatQcowRadio.setText("Qcow")
         self.uiFormatQcowRadio.setObjectName("uiFormatQcowRadio")
         self.uiFormatRadios.addButton(self.uiFormatQcowRadio)
         self.verticalLayout.addWidget(self.uiFormatQcowRadio)
-        self.uiFormatVpcRadio = QtWidgets.QRadioButton(self.uiFormatFrame)
-        self.uiFormatVpcRadio.setObjectName("uiFormatVpcRadio")
-        self.uiFormatRadios.addButton(self.uiFormatVpcRadio)
-        self.verticalLayout.addWidget(self.uiFormatVpcRadio)
+        self.uiFormatVhdRadio = QtWidgets.QRadioButton(self.uiFormatFrame)
+        self.uiFormatVhdRadio.setText("VHD")
+        self.uiFormatVhdRadio.setObjectName("uiFormatVhdRadio")
+        self.uiFormatRadios.addButton(self.uiFormatVhdRadio)
+        self.verticalLayout.addWidget(self.uiFormatVhdRadio)
         self.uiFormatVdiRadio = QtWidgets.QRadioButton(self.uiFormatFrame)
+        self.uiFormatVdiRadio.setText("VDI")
         self.uiFormatVdiRadio.setObjectName("uiFormatVdiRadio")
         self.uiFormatRadios.addButton(self.uiFormatVdiRadio)
         self.verticalLayout.addWidget(self.uiFormatVdiRadio)
         self.uiFormatVmdkRadio = QtWidgets.QRadioButton(self.uiFormatFrame)
+        self.uiFormatVmdkRadio.setText("VMDK")
         self.uiFormatVmdkRadio.setObjectName("uiFormatVmdkRadio")
         self.uiFormatRadios.addButton(self.uiFormatVmdkRadio)
         self.verticalLayout.addWidget(self.uiFormatVmdkRadio)
@@ -313,18 +316,13 @@ class Ui_QemuImageWizard:
         self.uiBinaryLabel.setText(_translate("QemuImageWizard", "Qemu-img binary:"))
         self.uiFormatLabel.setText(_translate("QemuImageWizard", "Image format:"))
         self.uiFormatQcow2Radio.setToolTip(_translate("QemuImageWizard", "Qcow2 is the current Qemu format, supporting many special features."))
-        self.uiFormatQcow2Radio.setText(_translate("QemuImageWizard", "Qcow2"))
         self.uiFormatQcowRadio.setToolTip(_translate("QemuImageWizard", "Qcow is a legacy Qemu format that is also supported by VirtualBox."))
-        self.uiFormatQcowRadio.setText(_translate("QemuImageWizard", "Qcow"))
-        self.uiFormatVpcRadio.setToolTip(_translate("QemuImageWizard", "VHD is the format used by Microsoft VirtualPC, and is also supported by Qemu and VirtualBox.\n"
-                                                    "On Windows 7 and above, it can be mounted on the host PC."))
-        self.uiFormatVpcRadio.setText(_translate("QemuImageWizard", "VHD"))
+        self.uiFormatVhdRadio.setToolTip(_translate("QemuImageWizard", "VHD is the format used by Microsoft VirtualPC, and is also supported by Qemu and VirtualBox.\n"
+"On Windows 7 and above, it can be mounted on the host PC."))
         self.uiFormatVdiRadio.setToolTip(_translate("QemuImageWizard", "VDI is the native format of VirtualBox"))
-        self.uiFormatVdiRadio.setText(_translate("QemuImageWizard", "VDI"))
         self.uiFormatVmdkRadio.setToolTip(_translate("QemuImageWizard", "VMDK is the native format for VMware and is also supported by Qemu and VirtualBox."))
-        self.uiFormatVmdkRadio.setText(_translate("QemuImageWizard", "VMDK"))
         self.uiFormatRawRadio.setToolTip(_translate("QemuImageWizard", "Raw image files represent the actual data on the image, with zero special features.\n"
-                                                    "It can easily be converted to various other formats by various utilities, making it the most portable format."))
+"It can easily be converted to various other formats by various utilities, making it the most portable format."))
         self.uiFormatRawRadio.setText(_translate("QemuImageWizard", "Raw"))
         self.uiQcow2OptionsWizardPage.setTitle(_translate("QemuImageWizard", "Qcow2 options"))
         self.uiSizeOptionsGroupBox.setTitle(_translate("QemuImageWizard", "Size options"))
@@ -332,12 +330,12 @@ class Ui_QemuImageWizard:
         self.uiQcow2PreallocationOffRadio.setToolTip(_translate("QemuImageWizard", "The file only takes as much space from the host as needed. The VM will still see the full capacity you specify."))
         self.uiQcow2PreallocationOffRadio.setText(_translate("QemuImageWizard", "off"))
         self.uiQcow2PreallocationMetadataRadio.setToolTip(_translate("QemuImageWizard", "Same as \"off\", but preallocates enough space to hold any potenial metadata for the HDD.\n"
-                                                                     "This improves performance when the image file needs to grow."))
+"This improves performance when the image file needs to grow."))
         self.uiQcow2PreallocationMetadataRadio.setText(_translate("QemuImageWizard", "metadata"))
         self.uiQcow2PreallocationFallocRadio.setToolTip(_translate("QemuImageWizard", "Same as \"full\", but uses C\'s posix_fallocate() if available on the host, instead of zero filling the file."))
         self.uiQcow2PreallocationFallocRadio.setText(_translate("QemuImageWizard", "falloc"))
         self.uiQcow2PreallocationFullRadio.setToolTip(_translate("QemuImageWizard", "The file will start off at the full size you specify.\n"
-                                                                 "Free space will be zero filled."))
+"Free space will be zero filled."))
         self.uiQcow2PreallocationFullRadio.setText(_translate("QemuImageWizard", "full"))
         self.uiClusterSizeLabel.setText(_translate("QemuImageWizard", "Cluster size:"))
         self.uiQcow2ClusterSizeComboBox.setItemText(0, _translate("QemuImageWizard", "<default>"))
@@ -397,3 +395,4 @@ class Ui_QemuImageWizard:
         self.uiLocationBrowseToolButton.setText(_translate("QemuImageWizard", "Browse"))
         self.uiSizeLabel.setText(_translate("QemuImageWizard", "Disk size:"))
         self.uiSizeSpinBox.setSuffix(_translate("QemuImageWizard", " MiB"))
+


### PR DESCRIPTION
Is likely to fix #395.

(Untested on Linux, but works fine on Windows, and since there's no use of text() anywhere except the file location, it *should* work fine on Linux too)