### PR TITLE
IOUVM converter

### DIFF
--- a/gns3/iouvm-converter.py
+++ b/gns3/iouvm-converter.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 GNS3 Technologies Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import sys
+import shutil
+import signal
+import json
+import os
+from datetime import datetime
+
+
+try:
+    from gns3.qt import QtCore, QtGui, QtWidgets, DEFAULT_BINDING
+except ImportError:
+    raise SystemExit("Can't import Qt modules: Qt and/or PyQt is probably not installed correctly...")
+
+import logging
+log = logging.getLogger(__name__)
+
+
+from gns3.version import __version__
+from gns3.local_config import LocalConfig
+from gns3.ui.iouvm_converter_wizard_ui import Ui_IOUVMConverterWizard
+
+class IOUVMConverterWizard(QtWidgets.QWizard, Ui_IOUVMConverterWizard):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.setWizardStyle(QtWidgets.QWizard.ModernStyle)
+        if sys.platform.startswith("darwin"):
+            # we want to see the cancel button on OSX
+            self.setOptions(QtWidgets.QWizard.NoDefaultButton)
+
+        # set the window icon
+        self.setWindowIcon(QtGui.QIcon(":/images/gns3.ico"))# this info is necessary for QSettings
+
+        config = self._loadConfig()
+        self.uiPushButtonBrowse.clicked.connect(self._browseTopologiesSlot)
+        self.uiLineEditTopologiesPath.setText(config['Servers']['local_server']['projects_path'])
+
+    def _browseTopologiesSlot(self):
+        path = QtWidgets.QFileDialog.getExistingDirectory(self, 'Select a directory')
+        self.uiLineEditTopologiesPath.setText(path)
+
+    def validateCurrentPage(self):
+        """
+        Validates the settings.
+        """
+
+        if self.currentPage() == self.uiWizardPageIOURCCheck:
+            return self._checkIOURC()
+        elif self.currentPage() == self.uiWizardUpdateConfiguration:
+            return self._updateConfig()
+        return True
+
+    def _checkIOURC(self):
+        """
+        Validate if the IOURC contain an entry for the IOUVM
+        """
+        config = self._loadConfig()
+        iourc_path = config.get("IOU", {}).get("iourc_path", "")
+        if len(iourc_path) == 0:
+            QtWidgets.QMessageBox.critical(self, "Error", "The IOURC is not configured")
+            return False
+        try:
+            with open(iourc_path) as f:
+                if 'gns3vm' not in f.read():
+                    QtWidgets.QMessageBox.critical(self, "Error", "The gns3vm doesn't exist in your iourc file".format(iourc_path))
+        except OSError:
+            QtWidgets.QMessageBox.critical(self, "Error", "IOURC file {} doesn't exist or not accessible".format(iourc_path))
+        return True
+
+    def _updateConfig(self):
+        config = self._loadConfig()
+        if "devices" in config["IOU"]:
+            for device in config["IOU"]["devices"]:
+                device["path"] = os.path.basename(device["path"])
+                device["server"] = "vm"
+        config["Servers"]["remote_servers"] = []
+        self._writeConfig(config)
+        return True
+
+    def _loadConfig(self):
+        with open(self._configurationFile()) as f:
+            return json.load(f)
+
+    def _writeConfig(self, config):
+        shutil.copy(self._configurationFile(), "{}.{}.backup".format(self._configurationFile(), datetime.now().isoformat()))
+        with open(self._configurationFile(), 'w+') as f:
+            json.dump(config, f)
+
+    def _configurationFile(self):
+        if sys.platform.startswith("win"):
+            filename = "gns3_gui.ini"
+        else:
+            filename = "gns3_gui.conf"
+        directory = LocalConfig.configDirectory()
+        return  os.path.join(directory, filename)
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+
+    app.setOrganizationName("GNS3")
+    app.setOrganizationDomain("gns3.net")
+    app.setApplicationName("GNS3")
+    app.setApplicationVersion(__version__)
+
+    # We force a full garbage collect before exit
+    # for unknow reason otherwise Qt Segfault on OSX in some
+    # conditions
+    import gc
+    gc.collect()
+
+    # Manage Ctrl + C or kill command
+    def sigint_handler(*args):
+        log.info("Signal received exiting the application")
+        app.closeAllWindows()
+    # signal.signal(signal.SIGINT, sigint_handler)
+    # signal.signal(signal.SIGTERM, sigint_handler)
+
+    mainwindow = IOUVMConverterWizard()
+    mainwindow.show()
+    exit_code = mainwindow.exec_()
+
+    # We force a full garbage collect before exit
+    # for unknow reason otherwise Qt Segfault on OSX in some
+    # conditions
+    import gc
+    gc.collect()
+
+    sys.exit(exit_code)
+
+if __name__ == '__main__':
+    main()

--- a/gns3/main_window.py
+++ b/gns3/main_window.py
@@ -27,6 +27,7 @@ import shutil
 import json
 import glob
 import logging
+import subprocess
 
 from .local_config import LocalConfig
 from .modules import MODULES
@@ -246,6 +247,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.uiLabInstructionsAction.triggered.connect(self._labInstructionsActionSlot)
         self.uiAboutQtAction.triggered.connect(self._aboutQtActionSlot)
         self.uiAboutAction.triggered.connect(self._aboutActionSlot)
+        self.uiIOUVMConverterAction.triggered.connect(self._IOUVMConverterActionSlot)
 
         # browsers tool bar connections
         self.uiBrowseRoutersAction.triggered.connect(self._browseRoutersActionSlot)
@@ -373,6 +375,9 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 self._createNewProject(new_project_settings)
             else:
                 self._createTemporaryProject()
+
+    def _IOUVMConverterActionSlot(self):
+        subprocess.Popen([shutil.which("gns3-iouvm-converter")])
 
     def openProjectActionSlot(self):
         """

--- a/gns3/main_window.py
+++ b/gns3/main_window.py
@@ -377,7 +377,14 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 self._createTemporaryProject()
 
     def _IOUVMConverterActionSlot(self):
-        subprocess.Popen([shutil.which("gns3-iouvm-converter")])
+        command = shutil.which("gns3-iouvm-converter")
+        if command is None:
+            QtWidgets.QMessageBox.critical(self, "gns3-iouvm-converter not found")
+            return
+        try:
+            subprocess.Popen([command])
+        except (OSError, subprocess.SubprocessError) as e:
+            QtWidgets.QMessageBox.critical(self, "Error when running gns3-iouvm-converter {}".format(e))
 
     def openProjectActionSlot(self):
         """

--- a/gns3/ui/iouvm_converter_wizard.ui
+++ b/gns3/ui/iouvm_converter_wizard.ui
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IOUVMConverterWizard</class>
+ <widget class="QWizard" name="IOUVMConverterWizard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>649</width>
+    <height>377</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>GNS3 IOU Converter</string>
+  </property>
+  <property name="options">
+   <set>QWizard::NoCancelButton|QWizard::NoDefaultButton</set>
+  </property>
+  <widget class="QWizardPage" name="uiWizardWelcomePage">
+   <layout class="QVBoxLayout" name="verticalLayout_2">
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>&lt;h1&gt;Welcome to the IOUVM converter&lt;/h1&gt;
+&lt;p&gt;This Wizard will help you to convert the IOUVM to the new GNS3 VM&lt;/p&gt;
+&lt;p&gt;The GNS3 VM has a self update system allowing you to easily upgrade between version of the GNS3 VM without manual operations.&lt;/p&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardStartConfigureGNS3">
+   <layout class="QVBoxLayout" name="verticalLayout_13">
+    <item>
+     <widget class="QLabel" name="label_14">
+      <property name="text">
+       <string>&lt;h1&gt;Start GNS3&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Start GNS3 &gt;= 1.4&lt;/li&gt;
+&lt;li&gt;Configure the GNS3 VM via preferences or the initial wizard&lt;/li&gt;
+&lt;li&gt;Exit all instance of GNS3&lt;/li&gt;
+&lt;/ul&gt;</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardVirtualBoxNatPage">
+   <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>&lt;h1&gt;Setup NAT&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Start VirtualBox &lt;/li&gt;
+&lt;li&gt;Click on the IOUVM&lt;/li&gt;
+&lt;li&gt;Click on settings&lt;/li&gt;
+&lt;li&gt;Click on Network&lt;/li&gt;
+&lt;li&gt;Change Host-only adapter to NAT&lt;/li&gt;
+&lt;li&gt;Click on OK&lt;/li&gt;
+&lt;li&gt;Start the VM&lt;li&gt;
+&lt;/ul&gt;</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardUpdateIOUVM">
+   <layout class="QVBoxLayout" name="verticalLayout_4">
+    <item>
+     <widget class="QLabel" name="label_3">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:xx-large; font-weight:600;&quot;&gt;Update GNS3 on IOUVM&lt;/span&gt;&lt;/p&gt;&lt;p&gt;In the VM: &lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Log as root with password CISCO&lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;pip3 install gns3-server==1.3.8&lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;halt&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::RichText</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardPageVirtualBoxHostOnly">
+   <layout class="QVBoxLayout" name="verticalLayout_5">
+    <item>
+     <widget class="QLabel" name="label_4">
+      <property name="text">
+       <string>&lt;h1&gt;Restore VM network settings&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Start VirtualBox &lt;/li&gt;
+&lt;li&gt;Click on the IOUVM&lt;/li&gt;
+&lt;li&gt;Click on settings&lt;/li&gt;
+&lt;li&gt;Click on Network&lt;/li&gt;
+&lt;li&gt;Change NAT adapter to Host-Only&lt;/li&gt;
+&lt;li&gt;Click on OK&lt;/li&gt;
+&lt;li&gt;Start the VM&lt;li&gt;
+&lt;/ul&gt;</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardRestoreBackups">
+   <layout class="QVBoxLayout" name="verticalLayout_11">
+    <item>
+     <widget class="QLabel" name="label_11">
+      <property name="text">
+       <string>&lt;h1&gt;Restore backups&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Start the GNS3 VM&lt;/li&gt;
+&lt;li&gt;Remember the IP display on the information screen&lt;/li&gt;
+&lt;li&gt;In a browser open http://THEIP:8000/upload&lt;/li&gt;
+&lt;li&gt;Select the option for restoring projects and upload the previous backup&lt;/li&gt;
+&lt;li&gt;Select the option for restoring images and upload the previous backup&lt;/li&gt;
+&lt;/ul&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardDownloadBackups">
+   <layout class="QVBoxLayout" name="verticalLayout_10">
+    <item>
+     <widget class="QLabel" name="label_10">
+      <property name="text">
+       <string>&lt;h1&gt;Download backups&lt;/h1&gt;
+&lt;ul&gt;
+&lt;li&gt;Log as root with password CISCO&lt;/li&gt;
+&lt;li&gt;Type ifconfig eth0&lt;/li&gt;
+&lt;li&gt;Remember the addr&lt;/li&gt;
+&lt;li&gt;In your browser open http://THEADDR:8000&lt;/li&gt;
+&lt;li&gt;Download projects and images backups&lt;/li&gt;
+&lt;/ul&gt;</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardPageBackup">
+   <layout class="QVBoxLayout" name="verticalLayout_6">
+    <item>
+     <widget class="QLabel" name="label_5">
+      <property name="font">
+       <font>
+        <pointsize>43</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>&lt;center&gt;
+BACKUP&lt;br&gt;
+YOUR TOPOLOGIES!
+&lt;/center&gt;</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardPageIOURCCheck">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="label_7">
+      <property name="text">
+       <string>&lt;h1&gt;Validation of the IOURC file&lt;/h1&gt; 
+The IOURC file contain your licence for IOU.&lt;br&gt;
+The format of file is:
+&lt;pre&gt;
+[license]
+gns3-iouvm = OLDLICENCE;
+gns3vm = NEWLICENCE;
+&lt;/pre&gt;
+&lt;br&gt;
+The GNS3VM require a new licence. You need to add it in the file. IOU is a CISCO product. GNS3 staff is not allowed to provide this licence.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardUpdateConfiguration">
+   <layout class="QVBoxLayout" name="verticalLayout_12">
+    <item>
+     <widget class="QLabel" name="label_12">
+      <property name="text">
+       <string>&lt;h1&gt;Update configuration&lt;/h1&gt;
+&lt;p style=&quot;color: red&quot;&gt;Your GNS3 configuration will be updated.&lt;/p&gt;
+&lt;p&gt;All your remote servers will be removed and replace by the GNS3VM. &lt;/p&gt;&lt;p&gt;If you have a custom remote server &lt;strong&gt;DO NOT CONTINUE&lt;/strong&gt;&lt;/p&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardPagePatchTopologies">
+   <layout class="QVBoxLayout" name="verticalLayout_7">
+    <item>
+     <widget class="QLabel" name="label_6">
+      <property name="text">
+       <string>&lt;h1&gt;Patch topologies&lt;/h1&gt;
+We need to patch your topologies please select your topologies directory</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLineEdit" name="uiLineEditTopologiesPath"/>
+      </item>
+      <item>
+       <widget class="QPushButton" name="uiPushButtonBrowse">
+        <property name="text">
+         <string>Browse...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWizardPage" name="uiWizardCongratulation">
+   <layout class="QVBoxLayout" name="verticalLayout_8">
+    <item>
+     <widget class="QLabel" name="label_8">
+      <property name="text">
+       <string>&lt;center&gt;
+&lt;h1&gt;Congratulation you can now use the GNS3 VM&lt;/h1&gt;
+&lt;/center&gt;</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/gns3/ui/iouvm_converter_wizard_ui.py
+++ b/gns3/ui/iouvm_converter_wizard_ui.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file '/Users/noplay/code/gns3/gns3-gui/gns3/ui/iouvm_converter_wizard.ui'
+#
+# Created by: PyQt5 UI code generator 5.4.2
+#
+# WARNING! All changes made in this file will be lost!
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+class Ui_IOUVMConverterWizard(object):
+    def setupUi(self, IOUVMConverterWizard):
+        IOUVMConverterWizard.setObjectName("IOUVMConverterWizard")
+        IOUVMConverterWizard.resize(649, 377)
+        IOUVMConverterWizard.setOptions(QtWidgets.QWizard.NoCancelButton|QtWidgets.QWizard.NoDefaultButton)
+        self.uiWizardWelcomePage = QtWidgets.QWizardPage()
+        self.uiWizardWelcomePage.setObjectName("uiWizardWelcomePage")
+        self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.uiWizardWelcomePage)
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
+        self.label = QtWidgets.QLabel(self.uiWizardWelcomePage)
+        self.label.setWordWrap(True)
+        self.label.setObjectName("label")
+        self.verticalLayout_2.addWidget(self.label)
+        IOUVMConverterWizard.addPage(self.uiWizardWelcomePage)
+        self.uiWizardStartConfigureGNS3 = QtWidgets.QWizardPage()
+        self.uiWizardStartConfigureGNS3.setObjectName("uiWizardStartConfigureGNS3")
+        self.verticalLayout_13 = QtWidgets.QVBoxLayout(self.uiWizardStartConfigureGNS3)
+        self.verticalLayout_13.setObjectName("verticalLayout_13")
+        self.label_14 = QtWidgets.QLabel(self.uiWizardStartConfigureGNS3)
+        self.label_14.setObjectName("label_14")
+        self.verticalLayout_13.addWidget(self.label_14)
+        IOUVMConverterWizard.addPage(self.uiWizardStartConfigureGNS3)
+        self.uiWizardVirtualBoxNatPage = QtWidgets.QWizardPage()
+        self.uiWizardVirtualBoxNatPage.setObjectName("uiWizardVirtualBoxNatPage")
+        self.verticalLayout_3 = QtWidgets.QVBoxLayout(self.uiWizardVirtualBoxNatPage)
+        self.verticalLayout_3.setObjectName("verticalLayout_3")
+        self.label_2 = QtWidgets.QLabel(self.uiWizardVirtualBoxNatPage)
+        self.label_2.setObjectName("label_2")
+        self.verticalLayout_3.addWidget(self.label_2)
+        IOUVMConverterWizard.addPage(self.uiWizardVirtualBoxNatPage)
+        self.uiWizardUpdateIOUVM = QtWidgets.QWizardPage()
+        self.uiWizardUpdateIOUVM.setObjectName("uiWizardUpdateIOUVM")
+        self.verticalLayout_4 = QtWidgets.QVBoxLayout(self.uiWizardUpdateIOUVM)
+        self.verticalLayout_4.setObjectName("verticalLayout_4")
+        self.label_3 = QtWidgets.QLabel(self.uiWizardUpdateIOUVM)
+        self.label_3.setTextFormat(QtCore.Qt.RichText)
+        self.label_3.setAlignment(QtCore.Qt.AlignLeading|QtCore.Qt.AlignLeft|QtCore.Qt.AlignVCenter)
+        self.label_3.setObjectName("label_3")
+        self.verticalLayout_4.addWidget(self.label_3)
+        IOUVMConverterWizard.addPage(self.uiWizardUpdateIOUVM)
+        self.uiWizardPageVirtualBoxHostOnly = QtWidgets.QWizardPage()
+        self.uiWizardPageVirtualBoxHostOnly.setObjectName("uiWizardPageVirtualBoxHostOnly")
+        self.verticalLayout_5 = QtWidgets.QVBoxLayout(self.uiWizardPageVirtualBoxHostOnly)
+        self.verticalLayout_5.setObjectName("verticalLayout_5")
+        self.label_4 = QtWidgets.QLabel(self.uiWizardPageVirtualBoxHostOnly)
+        self.label_4.setObjectName("label_4")
+        self.verticalLayout_5.addWidget(self.label_4)
+        IOUVMConverterWizard.addPage(self.uiWizardPageVirtualBoxHostOnly)
+        self.uiWizardRestoreBackups = QtWidgets.QWizardPage()
+        self.uiWizardRestoreBackups.setObjectName("uiWizardRestoreBackups")
+        self.verticalLayout_11 = QtWidgets.QVBoxLayout(self.uiWizardRestoreBackups)
+        self.verticalLayout_11.setObjectName("verticalLayout_11")
+        self.label_11 = QtWidgets.QLabel(self.uiWizardRestoreBackups)
+        self.label_11.setWordWrap(True)
+        self.label_11.setObjectName("label_11")
+        self.verticalLayout_11.addWidget(self.label_11)
+        IOUVMConverterWizard.addPage(self.uiWizardRestoreBackups)
+        self.uiWizardDownloadBackups = QtWidgets.QWizardPage()
+        self.uiWizardDownloadBackups.setObjectName("uiWizardDownloadBackups")
+        self.verticalLayout_10 = QtWidgets.QVBoxLayout(self.uiWizardDownloadBackups)
+        self.verticalLayout_10.setObjectName("verticalLayout_10")
+        self.label_10 = QtWidgets.QLabel(self.uiWizardDownloadBackups)
+        self.label_10.setObjectName("label_10")
+        self.verticalLayout_10.addWidget(self.label_10)
+        IOUVMConverterWizard.addPage(self.uiWizardDownloadBackups)
+        self.uiWizardPageBackup = QtWidgets.QWizardPage()
+        self.uiWizardPageBackup.setObjectName("uiWizardPageBackup")
+        self.verticalLayout_6 = QtWidgets.QVBoxLayout(self.uiWizardPageBackup)
+        self.verticalLayout_6.setObjectName("verticalLayout_6")
+        self.label_5 = QtWidgets.QLabel(self.uiWizardPageBackup)
+        font = QtGui.QFont()
+        font.setPointSize(43)
+        self.label_5.setFont(font)
+        self.label_5.setObjectName("label_5")
+        self.verticalLayout_6.addWidget(self.label_5)
+        IOUVMConverterWizard.addPage(self.uiWizardPageBackup)
+        self.uiWizardPageIOURCCheck = QtWidgets.QWizardPage()
+        self.uiWizardPageIOURCCheck.setObjectName("uiWizardPageIOURCCheck")
+        self.verticalLayout = QtWidgets.QVBoxLayout(self.uiWizardPageIOURCCheck)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.label_7 = QtWidgets.QLabel(self.uiWizardPageIOURCCheck)
+        self.label_7.setWordWrap(True)
+        self.label_7.setObjectName("label_7")
+        self.verticalLayout.addWidget(self.label_7)
+        IOUVMConverterWizard.addPage(self.uiWizardPageIOURCCheck)
+        self.uiWizardUpdateConfiguration = QtWidgets.QWizardPage()
+        self.uiWizardUpdateConfiguration.setObjectName("uiWizardUpdateConfiguration")
+        self.verticalLayout_12 = QtWidgets.QVBoxLayout(self.uiWizardUpdateConfiguration)
+        self.verticalLayout_12.setObjectName("verticalLayout_12")
+        self.label_12 = QtWidgets.QLabel(self.uiWizardUpdateConfiguration)
+        self.label_12.setWordWrap(True)
+        self.label_12.setObjectName("label_12")
+        self.verticalLayout_12.addWidget(self.label_12)
+        IOUVMConverterWizard.addPage(self.uiWizardUpdateConfiguration)
+        self.uiWizardPagePatchTopologies = QtWidgets.QWizardPage()
+        self.uiWizardPagePatchTopologies.setObjectName("uiWizardPagePatchTopologies")
+        self.verticalLayout_7 = QtWidgets.QVBoxLayout(self.uiWizardPagePatchTopologies)
+        self.verticalLayout_7.setObjectName("verticalLayout_7")
+        self.label_6 = QtWidgets.QLabel(self.uiWizardPagePatchTopologies)
+        self.label_6.setWordWrap(True)
+        self.label_6.setObjectName("label_6")
+        self.verticalLayout_7.addWidget(self.label_6)
+        self.horizontalLayout_2 = QtWidgets.QHBoxLayout()
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
+        self.uiLineEditTopologiesPath = QtWidgets.QLineEdit(self.uiWizardPagePatchTopologies)
+        self.uiLineEditTopologiesPath.setObjectName("uiLineEditTopologiesPath")
+        self.horizontalLayout_2.addWidget(self.uiLineEditTopologiesPath)
+        self.uiPushButtonBrowse = QtWidgets.QPushButton(self.uiWizardPagePatchTopologies)
+        self.uiPushButtonBrowse.setObjectName("uiPushButtonBrowse")
+        self.horizontalLayout_2.addWidget(self.uiPushButtonBrowse)
+        self.verticalLayout_7.addLayout(self.horizontalLayout_2)
+        IOUVMConverterWizard.addPage(self.uiWizardPagePatchTopologies)
+        self.uiWizardCongratulation = QtWidgets.QWizardPage()
+        self.uiWizardCongratulation.setObjectName("uiWizardCongratulation")
+        self.verticalLayout_8 = QtWidgets.QVBoxLayout(self.uiWizardCongratulation)
+        self.verticalLayout_8.setObjectName("verticalLayout_8")
+        self.label_8 = QtWidgets.QLabel(self.uiWizardCongratulation)
+        self.label_8.setWordWrap(True)
+        self.label_8.setObjectName("label_8")
+        self.verticalLayout_8.addWidget(self.label_8)
+        IOUVMConverterWizard.addPage(self.uiWizardCongratulation)
+
+        self.retranslateUi(IOUVMConverterWizard)
+        QtCore.QMetaObject.connectSlotsByName(IOUVMConverterWizard)
+
+    def retranslateUi(self, IOUVMConverterWizard):
+        _translate = QtCore.QCoreApplication.translate
+        IOUVMConverterWizard.setWindowTitle(_translate("IOUVMConverterWizard", "GNS3 IOU Converter"))
+        self.label.setText(_translate("IOUVMConverterWizard", "<h1>Welcome to the IOUVM converter</h1>\n"
+"<p>This Wizard will help you to convert the IOUVM to the new GNS3 VM</p>\n"
+"<p>The GNS3 VM has a self update system allowing you to easily upgrade between version of the GNS3 VM without manual operations.</p>"))
+        self.label_14.setText(_translate("IOUVMConverterWizard", "<h1>Start GNS3</h1>\n"
+"<ul>\n"
+"<li>Start GNS3 >= 1.4</li>\n"
+"<li>Configure the GNS3 VM via preferences or the initial wizard</li>\n"
+"<li>Exit all instance of GNS3</li>\n"
+"</ul>"))
+        self.label_2.setText(_translate("IOUVMConverterWizard", "<h1>Setup NAT</h1>\n"
+"<ul>\n"
+"<li>Start VirtualBox </li>\n"
+"<li>Click on the IOUVM</li>\n"
+"<li>Click on settings</li>\n"
+"<li>Click on Network</li>\n"
+"<li>Change Host-only adapter to NAT</li>\n"
+"<li>Click on OK</li>\n"
+"<li>Start the VM<li>\n"
+"</ul>"))
+        self.label_3.setText(_translate("IOUVMConverterWizard", "<html><head/><body><p><span style=\" font-size:xx-large; font-weight:600;\">Update GNS3 on IOUVM</span></p><p>In the VM: </p><ul style=\"margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;\"><li style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Log as root with password CISCO</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">pip3 install gns3-server==1.3.8</li><li style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">halt</li></ul></body></html>"))
+        self.label_4.setText(_translate("IOUVMConverterWizard", "<h1>Restore VM network settings</h1>\n"
+"<ul>\n"
+"<li>Start VirtualBox </li>\n"
+"<li>Click on the IOUVM</li>\n"
+"<li>Click on settings</li>\n"
+"<li>Click on Network</li>\n"
+"<li>Change NAT adapter to Host-Only</li>\n"
+"<li>Click on OK</li>\n"
+"<li>Start the VM<li>\n"
+"</ul>"))
+        self.label_11.setText(_translate("IOUVMConverterWizard", "<h1>Restore backups</h1>\n"
+"<ul>\n"
+"<li>Start the GNS3 VM</li>\n"
+"<li>Remember the IP display on the information screen</li>\n"
+"<li>In a browser open http://THEIP:8000/upload</li>\n"
+"<li>Select the option for restoring projects and upload the previous backup</li>\n"
+"<li>Select the option for restoring images and upload the previous backup</li>\n"
+"</ul>"))
+        self.label_10.setText(_translate("IOUVMConverterWizard", "<h1>Download backups</h1>\n"
+"<ul>\n"
+"<li>Log as root with password CISCO</li>\n"
+"<li>Type ifconfig eth0</li>\n"
+"<li>Remember the addr</li>\n"
+"<li>In your browser open http://THEADDR:8000</li>\n"
+"<li>Download projects and images backups</li>\n"
+"</ul>"))
+        self.label_5.setText(_translate("IOUVMConverterWizard", "<center>\n"
+"BACKUP<br>\n"
+"YOUR TOPOLOGIES!\n"
+"</center>"))
+        self.label_7.setText(_translate("IOUVMConverterWizard", "<h1>Validation of the IOURC file</h1> \n"
+"The IOURC file contain your licence for IOU.<br>\n"
+"The format of file is:\n"
+"<pre>\n"
+"[license]\n"
+"gns3-iouvm = OLDLICENCE;\n"
+"gns3vm = NEWLICENCE;\n"
+"</pre>\n"
+"<br>\n"
+"The GNS3VM require a new licence. You need to add it in the file. IOU is a CISCO product. GNS3 staff is not allowed to provide this licence."))
+        self.label_12.setText(_translate("IOUVMConverterWizard", "<h1>Update configuration</h1>\n"
+"<p style=\"color: red\">Your GNS3 configuration will be updated.</p>\n"
+"<p>All your remote servers will be removed and replace by the GNS3VM. </p><p>If you have a custom remote server <strong>DO NOT CONTINUE</strong></p>"))
+        self.label_6.setText(_translate("IOUVMConverterWizard", "<h1>Patch topologies</h1>\n"
+"We need to patch your topologies please select your topologies directory"))
+        self.uiPushButtonBrowse.setText(_translate("IOUVMConverterWizard", "Browse..."))
+        self.label_8.setText(_translate("IOUVMConverterWizard", "<center>\n"
+"<h1>Congratulation you can now use the GNS3 VM</h1>\n"
+"</center>"))
+

--- a/gns3/ui/main_window.ui
+++ b/gns3/ui/main_window.ui
@@ -168,6 +168,7 @@ background-none;
      <string>&amp;Tools</string>
     </property>
     <addaction name="uiVPCSAction"/>
+    <addaction name="uiIOUVMConverterAction"/>
    </widget>
    <addaction name="uiFileMenu"/>
    <addaction name="uiEditMenu"/>
@@ -1201,6 +1202,11 @@ background-none;
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
+   </property>
+  </action>
+  <action name="uiIOUVMConverterAction">
+   <property name="text">
+    <string>IOU VM Converter</string>
    </property>
   </action>
  </widget>

--- a/gns3/ui/main_window_ui.py
+++ b/gns3/ui/main_window_ui.py
@@ -366,8 +366,8 @@ class Ui_MainWindow(object):
         self.uiAddLinkAction.setCheckable(True)
         icon29 = QtGui.QIcon()
         icon29.addPixmap(QtGui.QPixmap(":/icons/connection-new-hover.svg"), QtGui.QIcon.Active, QtGui.QIcon.Off)
-        icon29.addPixmap(QtGui.QPixmap(":/icons/connection-new.svg"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         icon29.addPixmap(QtGui.QPixmap(":/icons/cancel-connection.svg"), QtGui.QIcon.Active, QtGui.QIcon.On)
+        icon29.addPixmap(QtGui.QPixmap(":/icons/connection-new.svg"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         icon29.addPixmap(QtGui.QPixmap(":/icons/cancel-connection.svg"), QtGui.QIcon.Normal, QtGui.QIcon.On)
         self.uiAddLinkAction.setIcon(icon29)
         self.uiAddLinkAction.setObjectName("uiAddLinkAction")
@@ -408,6 +408,8 @@ class Ui_MainWindow(object):
         self.uiSetupWizard = QtWidgets.QAction(MainWindow)
         self.uiSetupWizard.setMenuRole(QtWidgets.QAction.NoRole)
         self.uiSetupWizard.setObjectName("uiSetupWizard")
+        self.uiIOUVMConverterAction = QtWidgets.QAction(MainWindow)
+        self.uiIOUVMConverterAction.setObjectName("uiIOUVMConverterAction")
         self.uiEditMenu.addAction(self.uiSelectAllAction)
         self.uiEditMenu.addAction(self.uiSelectNoneAction)
         self.uiEditMenu.addSeparator()
@@ -458,6 +460,7 @@ class Ui_MainWindow(object):
         self.uiAnnotateMenu.addAction(self.uiDrawRectangleAction)
         self.uiAnnotateMenu.addAction(self.uiDrawEllipseAction)
         self.uiToolsMenu.addAction(self.uiVPCSAction)
+        self.uiToolsMenu.addAction(self.uiIOUVMConverterAction)
         self.uiMenuBar.addAction(self.uiFileMenu.menuAction())
         self.uiMenuBar.addAction(self.uiEditMenu.menuAction())
         self.uiMenuBar.addAction(self.uiViewMenu.menuAction())
@@ -663,6 +666,7 @@ class Ui_MainWindow(object):
         self.uiDownloadRemoteProject.setText(_translate("MainWindow", "Download remote project"))
         self.uiQemuImgWizardAction.setText(_translate("MainWindow", "Qemu image wizard"))
         self.uiSetupWizard.setText(_translate("MainWindow", "&Setup Wizard"))
+        self.uiIOUVMConverterAction.setText(_translate("MainWindow", "IOU VM Converter"))
 
 from ..console_view import ConsoleView
 from ..graphics_view import GraphicsView

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     entry_points={
         "gui_scripts": [
             "gns3 = gns3.main:main",
+            "gns3-iouvm-converter = gns3.iouvm_converter:main"
         ]
     },
     packages=find_packages(".", exclude=["docs", "tests"]),


### PR DESCRIPTION
Add a wizard for converting an IOUVM to a GNS3VM:
* check in iourc if the gns3vm is present
* remove all remote servers from configuration (a warning explain to users they should not use the converter if they use their own remote servers)
* patch all IOU devices in config to use the GNS3 VM
* update the topologies in a specified directory in order to use GNS3VM in place of their remote server

All the files are backuped up before modification, an entry in the tools menu of GNS3 is added. We need to modify the build in order to create the binaries.

The command could be start with python `gns3/iouvm_converter.py`

Fix #531 