### PR TITLE
Show the server choice in wizard if you have a VM or a remote server

### DIFF
--- a/gns3/dialogs/vm_wizard.py
+++ b/gns3/dialogs/vm_wizard.py
@@ -47,6 +47,10 @@ class VMWizard(QtWidgets.QWizard):
         # The list of radio button for existing image or new images
         self._radio_existing_images_buttons = set()
 
+        if Servers.instance().isNonLocalServerConfigured() is False:
+            # skip the server page if we use the local server
+            self.setStartId(1)
+
     def refreshImageStepsButtons(self):
         """
         When changing the server type (remote or local)

--- a/gns3/modules/dynamips/dialogs/ios_router_wizard.py
+++ b/gns3/modules/dynamips/dialogs/ios_router_wizard.py
@@ -111,10 +111,6 @@ class IOSRouterWizard(VMWizard, Ui_IOSRouterWizard):
 
         self._ios_routers = ios_routers
 
-        if Dynamips.instance().settings()["use_local_server"]:
-            # skip the server page if we use the local server
-            self.setStartId(1)
-
         from ..pages.ios_router_preferences_page import IOSRouterPreferencesPage
         self.addImageSelector(self.uiIOSExistingImageRadioButton, self.uiIOSImageListComboBox, self.uiIOSImageLineEdit, self.uiIOSImageToolButton, IOSRouterPreferencesPage.getIOSImage)
 

--- a/gns3/modules/iou/dialogs/iou_device_wizard.py
+++ b/gns3/modules/iou/dialogs/iou_device_wizard.py
@@ -61,12 +61,6 @@ class IOUDeviceWizard(VMWizard, Ui_IOUDeviceWizard):
 
         self._iou_devices = iou_devices
 
-        if IOU.instance().settings()["use_local_server"]:
-            # skip the server page if we use the local server
-            self.uiLocalRadioButton.setEnabled(True)
-            self.uiLocalRadioButton.setChecked(True)
-            self.setStartId(1)
-
         self.uiIOUImageLineEdit.textChanged.connect(self._imageLineEditTextChangedSlot)
 
         # location of the base config templates

--- a/gns3/modules/qemu/dialogs/qemu_vm_wizard.py
+++ b/gns3/modules/qemu/dialogs/qemu_vm_wizard.py
@@ -66,10 +66,6 @@ class QemuVMWizard(VMWizard, Ui_QemuVMWizard):
         self.addImageSelector(self.uiLinuxExistingImageRadioButton, self.uiInitrdImageListComboBox, self.uiInitrdImageLineEdit, self.uiInitrdImageToolButton, QemuVMConfigurationPage.getDiskImage)
         self.addImageSelector(self.uiLinuxExistingImageRadioButton, self.uiKernelImageListComboBox, self.uiKernelImageLineEdit, self.uiKernelImageToolButton, QemuVMConfigurationPage.getDiskImage)
 
-        if Qemu.instance().settings()["use_local_server"]:
-            # skip the server page if we use the local server
-            self.setStartId(1)
-
     def _typeChangedSlot(self, vm_type):
         """
         When the type of QEMU VM is changed.
@@ -158,7 +154,7 @@ class QemuVMWizard(VMWizard, Ui_QemuVMWizard):
 
             is_64bit = sys.maxsize > 2 ** 32
             if sys.platform.startswith("win"):
-                if self.uiTypeComboBox.currentText() != "Default" and (Qemu.instance().settings()["use_local_server"] or self.uiLocalRadioButton.isChecked()):
+                if self.uiTypeComboBox.currentText() != "Default" and self.uiLocalRadioButton.isChecked():
                     search_string = r"qemu-0.13.0\qemu-system-i386w.exe"
                 elif is_64bit:
                     # default is qemu-system-x86_64w.exe on Windows 64-bit with a remote server

--- a/gns3/modules/virtualbox/dialogs/virtualbox_vm_wizard.py
+++ b/gns3/modules/virtualbox/dialogs/virtualbox_vm_wizard.py
@@ -47,7 +47,7 @@ class VirtualBoxVMWizard(QtWidgets.QWizard, Ui_VirtualBoxVMWizard):
             # we want to see the cancel button on OSX
             self.setOptions(QtWidgets.QWizard.NoDefaultButton)
 
-        if Servers.instance().isNonLocalServerConfigured() is False:
+        if not Servers.instance().remoteServers():
             # skip the server page if we use the local server
             self.setStartId(1)
 

--- a/gns3/modules/virtualbox/dialogs/virtualbox_vm_wizard.py
+++ b/gns3/modules/virtualbox/dialogs/virtualbox_vm_wizard.py
@@ -47,7 +47,7 @@ class VirtualBoxVMWizard(QtWidgets.QWizard, Ui_VirtualBoxVMWizard):
             # we want to see the cancel button on OSX
             self.setOptions(QtWidgets.QWizard.NoDefaultButton)
 
-        if VirtualBox.instance().settings()["use_local_server"]:
+        if Servers.instance().isNonLocalServerConfigured() is False:
             # skip the server page if we use the local server
             self.setStartId(1)
 

--- a/gns3/modules/vmware/dialogs/vmware_vm_wizard.py
+++ b/gns3/modules/vmware/dialogs/vmware_vm_wizard.py
@@ -50,7 +50,7 @@ class VMwareVMWizard(QtWidgets.QWizard, Ui_VMwareVMWizard):
             # Fusion is not supported on OSX
             self.uiLocalRadioButton.setEnabled(False)
 
-        if Servers.instance().isNonLocalServerConfigured() is False:
+        if not Servers.instance().remoteServers():
             # skip the server page if we use the local server
             self.setStartId(1)
 

--- a/gns3/modules/vmware/dialogs/vmware_vm_wizard.py
+++ b/gns3/modules/vmware/dialogs/vmware_vm_wizard.py
@@ -47,7 +47,10 @@ class VMwareVMWizard(QtWidgets.QWizard, Ui_VMwareVMWizard):
             # we want to see the cancel button on OSX
             self.setOptions(QtWidgets.QWizard.NoDefaultButton)
 
-        if VMware.instance().settings()["use_local_server"]:
+            # Fusion is not supported on OSX
+            self.uiLocalRadioButton.setEnabled(False)
+
+        if Servers.instance().isNonLocalServerConfigured() is False:
             # skip the server page if we use the local server
             self.setStartId(1)
 

--- a/gns3/servers.py
+++ b/gns3/servers.py
@@ -55,7 +55,6 @@ class Servers():
         self._local_server = None
         self._vm_server = None
         self._remote_servers = {}
-        self._cloud_servers = {}
         self._local_server_path = ""
         self._local_server_auto_start = True
         self._local_server_allow_console_from_anywhere = False
@@ -673,6 +672,16 @@ class Servers():
         for server in self._remote_servers.values():
             if server.connected():
                 server.close()
+
+    def isNonLocalServerConfigured(self):
+        """
+        :returns: True if GNS3 VM or a remote server is configured
+        """
+        if self._vm_server is not None:
+            return True
+        if len(self._remote_servers) > 0:
+            return True
+        return False
 
     @staticmethod
     def instance():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,15 +208,3 @@ def pytest_unconfigure(config):
     del sys._called_from_test
 
 
-def pytest_runtest_setup(item):
-    """
-    Skip all tests marked with @rackspace_authentication if username and apikey were neither
-    passed to command line nor set as environment vars
-    """
-    user = item.config.getoption("--username") or os.environ.get('RACKSPACE_USERNAME')
-    key = item.config.getoption("--apikey") or os.environ.get('RACKSPACE_APIKEY')
-
-    credentials_passed = user and key
-
-    if 'rackspace_authentication' in item.keywords and not credentials_passed:
-        pytest.skip("need rackspace authentication options to run")

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -20,6 +20,10 @@ import pytest
 
 from gns3.servers import Servers
 
+@pytest.fixture(autouse=True)
+def reset_server():
+    Servers._instance = None
+
 
 def test_loadSettings_EmptySettings(local_config, tmpdir):
 
@@ -111,3 +115,17 @@ def test_getServerFromString_with_ssh():
     assert server.user() == "root"
     assert server.ssh_port() == 22
     assert server.ssh_key() == "/tmp/test.ssh"
+
+
+def test_is_non_local_server_configured():
+
+    servers = Servers.instance()
+
+    assert servers.isNonLocalServerConfigured() is False
+    servers._vm_server = object()
+    assert servers.isNonLocalServerConfigured() is True
+    servers._vm_server = None
+    assert servers.isNonLocalServerConfigured() is False
+
+    servers._addRemoteServer("ssh", "127.0.0.1", "4000", user="root", ssh_port=22, ssh_key="/tmp/test.ssh")
+    assert servers.isNonLocalServerConfigured() is True


### PR DESCRIPTION
It's easier for using instead of searching the screen with use
local server options.

But I think it's not complete because we still have the checkbox
in the preferences.

When I read the code I found this:
https://github.com/GNS3/gns3-gui/blob/cd9bb16f79e8738fff34ff695730163b92c11170/gns3/modules/builtin/__init__.py#L72

And I'm not sure in which case it's call. I think it's only for
VPCS and things like Dynamips switch. Is it right? If it's the case
we can drop the checkbox from IOU, Qemu, VMware, VirtualBox


Also another question. Is actually if we show the VM choice by default if the VM is running. I'm not sure if it's a good idea for Dynamips. Do we want users to move all to the VM ? It's an open question.