### PR TITLE
Send stats to GNS3 team

### DIFF
--- a/gns3/local_config.py
+++ b/gns3/local_config.py
@@ -161,14 +161,22 @@ class LocalConfig:
 
         settings = self.settings().get(section, dict())
 
+        missing = False
         # use default values for missing settings
         for name, value in default_settings.items():
             if name not in settings:
                 settings[name] = value
+                missing = True
 
         if section not in self._settings:
             self._settings[section] = {}
         self._settings[section].update(settings)
+
+        # If a value was not in setting file we store it
+        # on disk
+        if missing:
+            self.saveSectionSettings(section, settings)
+
         return settings
 
     def saveSectionSettings(self, section, settings):

--- a/gns3/main.py
+++ b/gns3/main.py
@@ -37,6 +37,7 @@ import argparse
 
 from gns3.logger import init_logger
 from gns3.crash_report import CrashReport
+from gns3.utils.analytics import AnalyticsClient
 
 
 import logging
@@ -226,6 +227,7 @@ def main():
 
     mainwindow = MainWindow(options.project)
     mainwindow.show()
+
     exit_code = app.exec_()
     delattr(MainWindow, "_instance")
     app.deleteLater()

--- a/gns3/pages/general_preferences_page.py
+++ b/gns3/pages/general_preferences_page.py
@@ -205,6 +205,7 @@ class GeneralPreferencesPage(QtGui.QWidget, Ui_GeneralPreferencesPageWidget):
         local_server = Servers.instance().localServerSettings()
         self.uiProjectsPathLineEdit.setText(local_server["projects_path"])
         self.uiImagesPathLineEdit.setText(local_server["images_path"])
+        self.uiStatsCheckBox.setChecked(settings["send_stats"])
         self.uiCrashReportCheckBox.setChecked(local_server["report_errors"])
         self.uiLaunchNewProjectDialogCheckBox.setChecked(settings["auto_launch_project_dialog"])
         self.uiAutoScreenshotCheckBox.setChecked(settings["auto_screenshot"])
@@ -284,6 +285,7 @@ class GeneralPreferencesPage(QtGui.QWidget, Ui_GeneralPreferencesPageWidget):
         new_settings["auto_close_console"] = self.uiCloseConsoleWindowsOnDeleteCheckBox.isChecked()
         new_settings["bring_console_to_front"] = self.uiBringConsoleWindowToFrontCheckBox.isChecked()
         new_settings["delay_console_all"] = self.uiDelayConsoleAllSpinBox.value()
+        new_settings["send_stats"] = self.uiStatsCheckBox.isChecked()
 
         from ..main_window import MainWindow
         MainWindow.instance().setSettings(new_settings)

--- a/gns3/qt.py
+++ b/gns3/qt.py
@@ -78,6 +78,37 @@ else:
     raise ImportError("Python binding not specified.")
 
 
+class StatsQtGuiQDialog(QtGui.QDialog):
+    """
+    Send stats from all the QWizard
+    """
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        import re
+        from .utils.analytics import AnalyticsClient
+        name = self.__class__.__name__
+        name = re.sub(r"([A-Z])", r" \1", name).strip()
+        AnalyticsClient.instance().sendScreenView(name)
+
+QtGui.QDialog = StatsQtGuiQDialog
+
+
+class StatsQtGuiQWizard(QtGui.QWizard):
+    """
+    Send stats from all the QWizard
+    """
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        import re
+        from .utils.analytics import AnalyticsClient
+        name = self.__class__.__name__
+        name = re.sub(r"([A-Z])", r" \1", name).strip()
+        AnalyticsClient.instance().sendScreenView(name)
+
+QtGui.QWizard = StatsQtGuiQWizard
+
 # If we run from a test we replace the signal by a synchronous version
 if hasattr(sys, '_called_from_test'):
     class FakeQtSignal:

--- a/gns3/settings.py
+++ b/gns3/settings.py
@@ -21,6 +21,7 @@ Default general settings.
 
 import os
 import sys
+import uuid
 import platform
 
 # Default projects directory location
@@ -183,6 +184,8 @@ GENERAL_SETTINGS = {
     "auto_launch_project_dialog": True,
     "auto_screenshot": True,
     "check_for_update": True,
+    "send_stats": True,
+    "stats_visitor_id": str(uuid.uuid4()), # An anonymous id for stats
     "last_check_for_update": 0,
     "slow_device_start_all": 0,
     "link_manual_mode": True,
@@ -201,6 +204,8 @@ GENERAL_SETTING_TYPES = {
     "auto_launch_project_dialog": bool,
     "auto_screenshot": bool,
     "check_for_update": bool,
+    "send_stats": bool,
+    "stats_visitor_id": str,
     "last_check_for_update": int,
     "slow_device_start_all": int,
     "link_manual_mode": bool,

--- a/gns3/ui/general_preferences_page.ui
+++ b/gns3/ui/general_preferences_page.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>467</width>
-    <height>536</height>
+    <width>510</width>
+    <height>577</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -546,6 +546,16 @@
         <widget class="QCheckBox" name="uiCrashReportCheckBox">
          <property name="text">
           <string>Automatically send crash reports</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="uiStatsCheckBox">
+         <property name="text">
+          <string>Send stats to GNS3 team</string>
          </property>
          <property name="checked">
           <bool>true</bool>

--- a/gns3/ui/general_preferences_page_ui.py
+++ b/gns3/ui/general_preferences_page_ui.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/grossmj/PycharmProjects/gns3-gui/gns3/ui/general_preferences_page.ui'
+# Form implementation generated from reading ui file '/Users/noplay/code/gns3/gns3-gui/gns3/ui/general_preferences_page.ui'
 #
-# Created: Fri Mar 13 15:27:54 2015
-#      by: PyQt4 UI code generator 4.10.4
+# Created: Sat Oct 10 22:06:44 2015
+#      by: PyQt4 UI code generator 4.11.3
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -26,7 +26,7 @@ except AttributeError:
 class Ui_GeneralPreferencesPageWidget(object):
     def setupUi(self, GeneralPreferencesPageWidget):
         GeneralPreferencesPageWidget.setObjectName(_fromUtf8("GeneralPreferencesPageWidget"))
-        GeneralPreferencesPageWidget.resize(467, 536)
+        GeneralPreferencesPageWidget.resize(510, 577)
         self.verticalLayout = QtGui.QVBoxLayout(GeneralPreferencesPageWidget)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.uiMiscTabWidget = QtGui.QTabWidget(GeneralPreferencesPageWidget)
@@ -275,6 +275,10 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiCrashReportCheckBox.setChecked(True)
         self.uiCrashReportCheckBox.setObjectName(_fromUtf8("uiCrashReportCheckBox"))
         self.verticalLayout_2.addWidget(self.uiCrashReportCheckBox)
+        self.uiStatsCheckBox = QtGui.QCheckBox(self.tab)
+        self.uiStatsCheckBox.setChecked(True)
+        self.uiStatsCheckBox.setObjectName(_fromUtf8("uiStatsCheckBox"))
+        self.verticalLayout_2.addWidget(self.uiStatsCheckBox)
         self.uiSlowStartAllLabel = QtGui.QLabel(self.tab)
         self.uiSlowStartAllLabel.setObjectName(_fromUtf8("uiSlowStartAllLabel"))
         self.verticalLayout_2.addWidget(self.uiSlowStartAllLabel)
@@ -349,6 +353,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiAutoScreenshotCheckBox.setText(_translate("GeneralPreferencesPageWidget", "Automatically take a screenshot when saving a project", None))
         self.uiCheckForUpdateCheckBox.setText(_translate("GeneralPreferencesPageWidget", "Automatically check for update", None))
         self.uiCrashReportCheckBox.setText(_translate("GeneralPreferencesPageWidget", "Automatically send crash reports", None))
+        self.uiStatsCheckBox.setText(_translate("GeneralPreferencesPageWidget", "Send stats to GNS3 team", None))
         self.uiSlowStartAllLabel.setText(_translate("GeneralPreferencesPageWidget", "Delay between each device start when starting all devices:", None))
         self.uiSlowStartAllSpinBox.setSuffix(_translate("GeneralPreferencesPageWidget", " seconds", None))
         self.uiMiscTabWidget.setTabText(self.uiMiscTabWidget.indexOf(self.tab), _translate("GeneralPreferencesPageWidget", "Miscellaneous", None))

--- a/gns3/utils/analytics.py
+++ b/gns3/utils/analytics.py
@@ -17,56 +17,108 @@
 
 
 import platform
-import uuid
+import sys
+from datetime import datetime
 
-from hashlib import md5
-from urllib.request import urlopen
 from urllib.parse import quote
-from ..qt import QtCore
 from ..version import __version__
+from ..qt import QtCore, QtNetwork, QtGui
+from ..local_config import LocalConfig
+from ..settings import GENERAL_SETTINGS
 
+import logging
+log = logging.getLogger(__name__)
 
-class AnalyticsClient(object):
+class AnalyticsClient(QtCore.QObject):
 
     """
     Google analytics client to send events.
     """
 
-    _property_id = "UA-55817127-1"
-    _visitor_id = None
-    _user_agent = "GNS3 {} on {}".format(__version__, platform.system())
+    _property_id = "UA-55817127-3"
 
-    def _generate_visitor_id(self):
+    def __init__(self):
+        super().__init__()
+        self._visitor_id = None
+        self._manager = QtNetwork.QNetworkAccessManager(self)
 
-        rstring = self._user_agent + str(uuid.uuid4())
-        md5_string = md5(rstring.encode()).hexdigest()
-        return "0x{}".format(md5_string[:16])
+        def finished(network_reply):
+            if network_reply.error() != QtNetwork.QNetworkReply.NoError:
+                log.critical("Error when pushing to Google Analytics %s", network_reply.errorString())
 
-    def send_event(self, category, action, label, value=None):
+        self._manager.finished.connect(finished)
 
-        if not self._visitor_id:
-            self._visitor_id = self._generate_visitor_id()
+        #
+        # We need to build a user agent for Universal Analytics in order to
+        # let analytics guess the OS
+        # this could break by analytics at anytime :(
+        if sys.platform.startswith("darwin"):
+            self._user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X {release}) AppleWebKit/537.36 (KHTML, like Gecko) GNS3/{version}".format(release=platform.mac_ver()[0].replace(".", "_"), version=__version__)
+        elif sys.platform.startswith("win"):
+            self._user_agent = "Mozilla/5.0 (Windows NT {}) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 GNS3/{version}".format(release=platform.release(), version=__version_)
+        else:
+            self._user_agent = "Mozilla/5.0 (X11; Linux {arch}) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36  GNS3/{version}".format(arch=platform.machine(), version=__version__)
+        self._rate_limit = {}
 
-        url = "http://www.google-analytics.com/__utm.gif?utmwv=5.3.6&utmac={property}" \
-            "&utmcc=__utma%3D999.999.999.999.999.1%3B&utmvid={visitor}&utmt=event&" \
-            "utme=5%28{category}*{action}*{label}%29".format(property=self._property_id,
-                                                             visitor=self._visitor_id,
-                                                             category=quote(category),
-                                                             action=quote(action),
-                                                             label=quote(label))
+    def sendScreenView(self, screen, session_start=None):
+        """
+        :params session_start: True session start, None during session, False session stop
+        """
 
-        if value is not None:
-            url += "%28{value}%29".format(value=value)
+        if session_start is not False and screen in self._rate_limit:
+            if self._rate_limit[screen] + 60 * 1 > datetime.utcnow().timestamp():
+                log.debug("Ignore call %s to Google Analytics because of rate limiting", screen)
+                return
+
+        self._rate_limit[screen] = datetime.utcnow().timestamp()
+
+        settings = LocalConfig.instance().loadSectionSettings("MainWindow", GENERAL_SETTINGS)
+        if settings["send_stats"] is False:
+            log.debug("Stats is turn off ignore call %s", screen)
+            return
+
+        body =  "v=1" #Version
+        body += "&tid={}".format(self._property_id) # Tracking ID / Property ID
+        body += "&cid={}".format(settings["stats_visitor_id"]) # Anonymous Client ID
+        body += "&aip=1" # Anonymize IP
+        body += "&t=screenview" # Screenview hit type
+        body += "&an=GNS3" # App name
+        body += "&av={}".format(quote(__version__)) # App version.
+        body += "&ua={}".format(quote(self._user_agent)) # User agent
+        body += "&cd={}".format(quote(screen)) # Category
+        body += "&ds=gns3-gui" # Data source
+        if session_start is True:
+            body += "&sc=start" # Session start
+        elif session_start is False:
+            body += "&sc=end" # Session end
+
+        screen = QtGui.QApplication.desktop().screenGeometry()
+        body += "&sr={}x{}".format(screen.width(), screen.height()) # Screen resolution
 
         locale = QtCore.QLocale.system().name().lower()
         if locale:
-            url += "&utmul={}".format(locale)
+            body += "&ul={}".format(locale) # User language
 
-        try:
-            urlopen(url, timeout=3)
-        except Exception:
-            pass
+        # TODO: HTTPS when possible because it's broken for the moment with Qt on OSX:
+        # https://bugreports.qt.io/browse/QTBUG-45487
+        if sys.platform.startswith("darwin"):
+            url = QtCore.QUrl('http://www.google-analytics.com/collect');
+        else:
+            url = QtCore.QUrl('https://www.google-analytics.com/collect');
+        request_qt = QtNetwork.QNetworkRequest(url)
+        request_qt.setRawHeader("Content-Type", "application/x-www-form-urlencoded")
+        request_qt.setRawHeader("User-Agent", self._user_agent)
+        self._manager.post(request_qt, body)
 
-if __name__ == '__main__':
-    client = AnalyticsClient()
-    client.send_event("Windows installer", "Install", __version__)
+        log.debug("Send stats to Google Analytics: %s", body)
+
+    @staticmethod
+    def instance():
+        """
+        Singleton to return only on instance of AnalyticsClient.
+        :returns: instance of AnalyticsClient
+        """
+
+        if not hasattr(AnalyticsClient, '_instance') or AnalyticsClient._instance is None:
+            AnalyticsClient._instance = AnalyticsClient()
+        return AnalyticsClient._instance


### PR DESCRIPTION
:warning: Not for merge just for review. Need to change tracking ID before

The target is to send to us some basic critical stats for measuring:
* OS usage
* Number or active users

OS usage is important because on Linux, we have only partial download stats due to the use of package from outside websites.

This PR:
* add settings for turning off analytics
* send a stats when the application start and at each save (for measuring session duration)
* rate limit the sending of stats (one call / minute max)
* fail without problem when network is down
* generate an unique id for user and keep it (for measuring returning / new users)
* set the settings anonymous IP to true
* send OS version and screen size

This PR will not for privacy reasons:
* send private information (email, mac address)
* send information about images used by users
