### PR TITLE
Allow to use the VNC port range for console

### DIFF
--- a/gns3/pages/server_preferences_page.py
+++ b/gns3/pages/server_preferences_page.py
@@ -447,11 +447,6 @@ class ServerPreferencesPage(QtWidgets.QWidget, Ui_ServerPreferencesPageWidget):
                                                                                                              new_local_server_settings["udp_end_port_range"]))
             return
 
-        if 5900 <= new_local_server_settings["console_start_port_range"] <= 6000 or 5900 <= new_local_server_settings["console_end_port_range"] <= 6000 \
-                or new_local_server_settings["console_start_port_range"] < 5900 and new_local_server_settings["console_end_port_range"] > 6000:
-            QtWidgets.QMessageBox.critical(self, "Port range", "Console port range between 5900 and 6000 is reserved for VNC")
-            return
-
         if new_local_server_settings["auto_start"]:
             if not os.path.isfile(new_local_server_settings["path"]):
                 QtWidgets.QMessageBox.critical(self, "Local server", "Could not find local server {}".format(new_local_server_settings["path"]))

--- a/gns3/ui/server_preferences_page.ui
+++ b/gns3/ui/server_preferences_page.ui
@@ -162,7 +162,7 @@
        <item>
         <widget class="QGroupBox" name="uiConsolePortRangeGroupBox">
          <property name="title">
-          <string>Console port range</string>
+          <string>Console port range (5900 =&gt; 6000 is shared with VNC)</string>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_7">
           <item>
@@ -437,7 +437,7 @@
           <item row="1" column="1">
            <widget class="QLineEdit" name="uiVMPasswordLineEdit">
             <property name="inputMethodHints">
-             <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText</set>
+             <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
             </property>
             <property name="echoMode">
              <enum>QLineEdit::Password</enum>
@@ -601,7 +601,7 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="currentText" stdset="0">
+         <property name="currentText">
           <string>HTTP</string>
          </property>
          <item>
@@ -703,7 +703,7 @@
        <item row="6" column="1">
         <widget class="QLineEdit" name="uiRemoteServerPasswordLineEdit">
          <property name="inputMethodHints">
-          <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText</set>
+          <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
          </property>
          <property name="text">
           <string/>

--- a/gns3/ui/server_preferences_page_ui.py
+++ b/gns3/ui/server_preferences_page_ui.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/grossmj/PycharmProjects/gns3-gui/gns3/ui/server_preferences_page.ui'
+# Form implementation generated from reading ui file '/Users/noplay/code/gns3/gns3-gui/gns3/ui/server_preferences_page.ui'
 #
-# Created: Sun Nov  1 18:17:05 2015
-#      by: PyQt5 UI code generator 5.2.1
+# Created by: PyQt5 UI code generator 5.5.1
 #
 # WARNING! All changes made in this file will be lost!
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-
 class Ui_ServerPreferencesPageWidget(object):
-
     def setupUi(self, ServerPreferencesPageWidget):
         ServerPreferencesPageWidget.setObjectName("ServerPreferencesPageWidget")
         ServerPreferencesPageWidget.resize(500, 609)
@@ -137,6 +134,10 @@ class Ui_ServerPreferencesPageWidget(object):
         self.verticalLayout.addWidget(self.uiUDPPortRangeGroupBox)
         spacerItem2 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
         self.verticalLayout.addItem(spacerItem2)
+        self.uiGeneralSettingsGroupBox.raise_()
+        self.uiConsolePortRangeGroupBox.raise_()
+        self.uiUDPPortRangeGroupBox.raise_()
+        self.uiLocalServerAutoStartCheckBox.raise_()
         self.uiServerPreferenceTabWidget.addTab(self.uiLocalTabWidget, "")
         self.uiGNS3VMTabWidget = QtWidgets.QWidget()
         self.uiGNS3VMTabWidget.setObjectName("uiGNS3VMTabWidget")
@@ -209,7 +210,7 @@ class Ui_ServerPreferencesPageWidget(object):
         self.uiVMPasswordLabel.setObjectName("uiVMPasswordLabel")
         self.gridLayout_3.addWidget(self.uiVMPasswordLabel, 1, 0, 1, 1)
         self.uiVMPasswordLineEdit = QtWidgets.QLineEdit(self.groupBox)
-        self.uiVMPasswordLineEdit.setInputMethodHints(QtCore.Qt.ImhHiddenText | QtCore.Qt.ImhNoAutoUppercase | QtCore.Qt.ImhNoPredictiveText)
+        self.uiVMPasswordLineEdit.setInputMethodHints(QtCore.Qt.ImhHiddenText|QtCore.Qt.ImhNoAutoUppercase|QtCore.Qt.ImhNoPredictiveText|QtCore.Qt.ImhSensitiveData)
         self.uiVMPasswordLineEdit.setEchoMode(QtWidgets.QLineEdit.Password)
         self.uiVMPasswordLineEdit.setObjectName("uiVMPasswordLineEdit")
         self.gridLayout_3.addWidget(self.uiVMPasswordLineEdit, 1, 1, 1, 1)
@@ -321,7 +322,7 @@ class Ui_ServerPreferencesPageWidget(object):
         self.uiRemoteServerSSHPortSpinBox.setObjectName("uiRemoteServerSSHPortSpinBox")
         self.gridLayout_5.addWidget(self.uiRemoteServerSSHPortSpinBox, 7, 1, 1, 1)
         self.uiRemoteServerPasswordLineEdit = QtWidgets.QLineEdit(self.uiRemoteTabWidget)
-        self.uiRemoteServerPasswordLineEdit.setInputMethodHints(QtCore.Qt.ImhHiddenText | QtCore.Qt.ImhNoAutoUppercase | QtCore.Qt.ImhNoPredictiveText)
+        self.uiRemoteServerPasswordLineEdit.setInputMethodHints(QtCore.Qt.ImhHiddenText|QtCore.Qt.ImhNoAutoUppercase|QtCore.Qt.ImhNoPredictiveText|QtCore.Qt.ImhSensitiveData)
         self.uiRemoteServerPasswordLineEdit.setText("")
         self.uiRemoteServerPasswordLineEdit.setEchoMode(QtWidgets.QLineEdit.Password)
         self.uiRemoteServerPasswordLineEdit.setObjectName("uiRemoteServerPasswordLineEdit")
@@ -329,6 +330,22 @@ class Ui_ServerPreferencesPageWidget(object):
         self.uiRemoteServerPasswordLabel = QtWidgets.QLabel(self.uiRemoteTabWidget)
         self.uiRemoteServerPasswordLabel.setObjectName("uiRemoteServerPasswordLabel")
         self.gridLayout_5.addWidget(self.uiRemoteServerPasswordLabel, 6, 0, 1, 1)
+        self.uiRemoteServerProtocolComboBox.raise_()
+        self.uiRemoteServerHostLabel.raise_()
+        self.uiRemoteServerPortLineEdit.raise_()
+        self.uiRemoteServerPortLabel.raise_()
+        self.uiRemoteServerPortSpinBox.raise_()
+        self.uiRAMLimitLabel.raise_()
+        self.uiRAMLimitSpinBox.raise_()
+        self.uiRemoteServerUserLabel.raise_()
+        self.uiRemoteServerUserLineEdit.raise_()
+        self.uiRemoteServerSSHPortLabel.raise_()
+        self.uiRemoteServerSSHPortSpinBox.raise_()
+        self.uiRemoteServerSSHKeyLabel.raise_()
+        self.uiRemoteServersTreeWidget.raise_()
+        self.uiRemoteServerProtocolLabel.raise_()
+        self.uiRemoteServerPasswordLineEdit.raise_()
+        self.uiRemoteServerPasswordLabel.raise_()
         self.uiServerPreferenceTabWidget.addTab(self.uiRemoteTabWidget, "")
         self.uiLoadBalancingTabWidget = QtWidgets.QWidget()
         self.uiLoadBalancingTabWidget.setObjectName("uiLoadBalancingTabWidget")
@@ -418,7 +435,7 @@ class Ui_ServerPreferencesPageWidget(object):
         self.uiLocalServerPortLabel.setText(_translate("ServerPreferencesPageWidget", "Port:"))
         self.uiConsoleConnectionsToAnyIPCheckBox.setText(_translate("ServerPreferencesPageWidget", "Allow console connections to any local IP address"))
         self.uiLocalServerAuthCheckBox.setText(_translate("ServerPreferencesPageWidget", "Protect server with password (recommended)"))
-        self.uiConsolePortRangeGroupBox.setTitle(_translate("ServerPreferencesPageWidget", "Console port range"))
+        self.uiConsolePortRangeGroupBox.setTitle(_translate("ServerPreferencesPageWidget", "Console port range (5900 => 6000 is shared with VNC)"))
         self.uiConsolePortRangeLabel.setText(_translate("ServerPreferencesPageWidget", "to"))
         self.uiUDPPortRangeGroupBox.setTitle(_translate("ServerPreferencesPageWidget", "UDP tunneling port range"))
         self.uiUDPPortRangeLabel.setText(_translate("ServerPreferencesPageWidget", "to"))
@@ -445,7 +462,7 @@ class Ui_ServerPreferencesPageWidget(object):
         self.uiDeleteRemoteServerPushButton.setText(_translate("ServerPreferencesPageWidget", "&Delete"))
         self.uiRemoteServersTreeWidget.headerItem().setText(3, _translate("ServerPreferencesPageWidget", "User"))
         self.uiRemoteServerProtocolLabel.setText(_translate("ServerPreferencesPageWidget", "Protocol:"))
-        self.uiRemoteServerProtocolComboBox.setProperty("currentText", _translate("ServerPreferencesPageWidget", "HTTP"))
+        self.uiRemoteServerProtocolComboBox.setCurrentText(_translate("ServerPreferencesPageWidget", "HTTP"))
         self.uiRemoteServerProtocolComboBox.setItemText(0, _translate("ServerPreferencesPageWidget", "HTTP"))
         self.uiRemoteServerProtocolComboBox.setItemText(1, _translate("ServerPreferencesPageWidget", "HTTPS"))
         self.uiRemoteServerProtocolComboBox.setItemText(2, _translate("ServerPreferencesPageWidget", "SSH"))
@@ -463,3 +480,4 @@ class Ui_ServerPreferencesPageWidget(object):
         self.uiRendezVousHashingRadioButton.setText(_translate("ServerPreferencesPageWidget", "Rendezvous hashing"))
         self.uiServerPreferenceTabWidget.setTabText(self.uiServerPreferenceTabWidget.indexOf(self.uiLoadBalancingTabWidget), _translate("ServerPreferencesPageWidget", "Load Balancing"))
         self.uiRestoreDefaultsPushButton.setText(_translate("ServerPreferencesPageWidget", "Restore defaults"))
+


### PR DESCRIPTION
This PR allow user to have VNC port in the
console port range. It's not a problem because server
can share the range (we have a common list for all tcp ports).

And we add an informations in the settings in order to allow user
to know that 5900 => 6000 will be used.

![capture d ecran 2015-12-02 a 16 08 27](https://cloud.githubusercontent.com/assets/345437/11534526/76d0c9b4-990f-11e5-9cac-4e4e67b2ca08.png)


Fix #846, #839