### PR TITLE
Added missing Qemu adapters to the topology schema.

### DIFF
--- a/gns3/schemas/topology.json
+++ b/gns3/schemas/topology.json
@@ -400,7 +400,28 @@
                 "usage": { "type": "string" },
                 "acpi_shutdown": { "type": "boolean" },
                 "adapter_type": {
-                    "enum": ["e1000", "i82551", "i82557b", "i82559er", "ne2k_pci", "pcnet", "rtl8139", "virtio", "virtio-net-pci"]
+                    "enum": [
+                        "e1000",
+                        "i82550",
+                        "i82551",
+                        "i82557a",
+                        "i82557b",
+                        "i82557c",
+                        "i82558a",
+                        "i82558b",
+                        "i82559a",
+                        "i82559b",
+                        "i82559c",
+                        "i82559er",
+                        "i82562",
+                        "i82801",
+                        "ne2k_pci",
+                        "pcnet",
+                        "rtl8139",
+                        "virtio",
+                        "virtio-net-pci",
+                        "vmxnet3"
+                    ]
                 },
                 "adapters": {"type": "integer", "minimum": 1},
                 "cpu_throttling": {"type": "integer", "minimum": 0, "maximum": 100},


### PR DESCRIPTION
I was making a topology with a device having a vmxnet3 interface, when a validation error popped up.

After tracking it down in the schema, I noticed it also misses several other network adapter types. This PR adds all of them, or at least all that are visible in the GNS3 1.4.0 GUI (I don't know if Qemu itself supports any additional ones), plus it intentionally formats them on multiple lines, ordered like the GUI list, for easier comparison, diff and additions in the future.