### PR TITLE
Port names with numbers starting from 1

### DIFF
--- a/gns3/modules/qemu/pages/qemu_vm_configuration_page.py
+++ b/gns3/modules/qemu/pages/qemu_vm_configuration_page.py
@@ -501,14 +501,14 @@ class QemuVMConfigurationPage(QtWidgets.QWidget, Ui_QemuVMConfigPageWidget):
 
             settings["category"] = self.uiCategoryComboBox.itemData(self.uiCategoryComboBox.currentIndex())
             port_name_format = self.uiPortNameFormatLineEdit.text()
-            if '{0}' not in port_name_format:
-                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain at least {0}")
+            if '{0}' not in port_name_format and '{port0}' not in port_name_format and '{port1}' not in port_name_format:
+                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain at least {0}, {port0} or {port1}")
             else:
                 settings["port_name_format"] = self.uiPortNameFormatLineEdit.text()
 
             port_segment_size = self.uiPortSegmentSizeSpinBox.value()
-            if port_segment_size and '{1}' not in port_name_format:
-                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain {1} if the segment size is not 0")
+            if port_segment_size and '{1}' not in port_name_format and '{segment0}' not in port_name_format and '{segment1}' not in port_name_format:
+                QtWidgets.QMessageBox.critical(self, "Port name format", "If the segment size is not 0, the format must contain {1}, {segment0} or {segment1}")
             else:
                 settings["port_segment_size"] = port_segment_size
 

--- a/gns3/modules/qemu/qemu_vm.py
+++ b/gns3/modules/qemu/qemu_vm.py
@@ -99,7 +99,14 @@ class QemuVM(VM):
             if self._first_port_name and adapter_number == 0:
                 port_name = self._first_port_name
             else:
-                port_name = self._port_name_format.format(interface_number, segment_number)
+                port_name = self._port_name_format.format(
+                    interface_number,
+                    segment_number,
+                    port0 = interface_number,
+                    port1 = 1 + interface_number,
+                    segment0 = segment_number,
+                    segment1 = 1 + segment_number
+                )
                 interface_number += 1
                 if self._port_segment_size and interface_number % self._port_segment_size == 0:
                     segment_number += 1

--- a/gns3/modules/qemu/ui/qemu_vm_configuration_page.ui
+++ b/gns3/modules/qemu/ui/qemu_vm_configuration_page.ui
@@ -523,6 +523,9 @@
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="uiPortNameFormatLabel">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;{0} - the port number, from 0 to the number of adapters-1.&lt;/p&gt;&lt;p&gt;{1} - the segment number, from 0 to the number of segments-1.&lt;/p&gt;&lt;p&gt;{port0} - named alias for {0}.&lt;/p&gt;&lt;p&gt;{port1} - the port number, from 1 to the number of adapters.&lt;/p&gt;&lt;p&gt;{segment0} - named alias for {1}.&lt;/p&gt;&lt;p&gt;{segment1} - the segment number, from 1 to the number of segments.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
          <property name="text">
           <string>Name format:</string>
          </property>

--- a/gns3/modules/qemu/ui/qemu_vm_configuration_page_ui.py
+++ b/gns3/modules/qemu/ui/qemu_vm_configuration_page_ui.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/grossmj/PycharmProjects/gns3-gui/gns3/modules/qemu/ui/qemu_vm_configuration_page.ui'
+# Form implementation generated from reading ui file 'D:\Vasko\PyCharmProjects\gns3-gui\gns3\modules\qemu\ui\qemu_vm_configuration_page.ui'
 #
-# Created: Sun Oct 18 19:06:42 2015
-#      by: PyQt5 UI code generator 5.2.1
+# Created by: PyQt5 UI code generator 5.5.1
 #
 # WARNING! All changes made in this file will be lost!
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-
 class Ui_QemuVMConfigPageWidget(object):
-
     def setupUi(self, QemuVMConfigPageWidget):
         QemuVMConfigPageWidget.setObjectName("QemuVMConfigPageWidget")
         QemuVMConfigPageWidget.resize(611, 524)
@@ -388,6 +385,10 @@ class Ui_QemuVMConfigPageWidget(object):
         self.uiACPIShutdownCheckBox = QtWidgets.QCheckBox(self.groupBox)
         self.uiACPIShutdownCheckBox.setObjectName("uiACPIShutdownCheckBox")
         self.gridLayout_3.addWidget(self.uiACPIShutdownCheckBox, 2, 0, 1, 2)
+        self.uiQemuOptionsLineEdit.raise_()
+        self.uiQemuOptionsLabel.raise_()
+        self.uiACPIShutdownCheckBox.raise_()
+        self.uiBaseVMCheckBox.raise_()
         self.verticalLayout_2.addWidget(self.groupBox)
         spacerItem4 = QtWidgets.QSpacerItem(20, 90, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
         self.verticalLayout_2.addItem(spacerItem4)
@@ -446,6 +447,7 @@ class Ui_QemuVMConfigPageWidget(object):
         self.uiAdapterTypesLabel.setText(_translate("QemuVMConfigPageWidget", "Type:"))
         self.uiAdaptersLabel.setText(_translate("QemuVMConfigPageWidget", "Adapters:"))
         self.uiMacAddrLabel.setText(_translate("QemuVMConfigPageWidget", "Base MAC:"))
+        self.uiPortNameFormatLabel.setToolTip(_translate("QemuVMConfigPageWidget", "<html><head/><body><p>{0} - the port number, from 0 to the number of adapters-1.</p><p>{1} - the segment number, from 0 to the number of segments-1.</p><p>{port0} - named alias for {0}.</p><p>{port1} - the port number, from 1 to the number of adapters.</p><p>{segment0} - named alias for {1}.</p><p>{segment1} - the segment number, from 1 to the number of segments.</p></body></html>"))
         self.uiPortNameFormatLabel.setText(_translate("QemuVMConfigPageWidget", "Name format:"))
         self.uiFirstPortNameLabel.setText(_translate("QemuVMConfigPageWidget", "First port name:"))
         self.uiQemutabWidget.setTabText(self.uiQemutabWidget.indexOf(self.uiNetworkTab), _translate("QemuVMConfigPageWidget", "Network"))
@@ -471,3 +473,4 @@ class Ui_QemuVMConfigPageWidget(object):
         self.uiBaseVMCheckBox.setText(_translate("QemuVMConfigPageWidget", "Use as a linked base VM"))
         self.uiACPIShutdownCheckBox.setText(_translate("QemuVMConfigPageWidget", "Enable ACPI shutdown (experimental)"))
         self.uiQemutabWidget.setTabText(self.uiQemutabWidget.indexOf(self.uiAdvancedSettingsTab), _translate("QemuVMConfigPageWidget", "Advanced settings"))
+

--- a/gns3/modules/virtualbox/pages/virtualbox_vm_configuration_page.py
+++ b/gns3/modules/virtualbox/pages/virtualbox_vm_configuration_page.py
@@ -185,14 +185,14 @@ class VirtualBoxVMConfigurationPage(QtWidgets.QWidget, Ui_virtualBoxVMConfigPage
 
             settings["category"] = self.uiCategoryComboBox.itemData(self.uiCategoryComboBox.currentIndex())
             port_name_format = self.uiPortNameFormatLineEdit.text()
-            if '{0}' not in port_name_format:
-                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain at least {0}")
+            if '{0}' not in port_name_format and '{port0}' not in port_name_format and '{port1}' not in port_name_format:
+                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain at least {0}, {port0} or {port1}")
             else:
                 settings["port_name_format"] = self.uiPortNameFormatLineEdit.text()
 
             port_segment_size = self.uiPortSegmentSizeSpinBox.value()
-            if port_segment_size and '{1}' not in port_name_format:
-                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain {1} if the segment size is not 0")
+            if port_segment_size and '{1}' not in port_name_format and '{segment0}' not in port_name_format and '{segment1}' not in port_name_format:
+                QtWidgets.QMessageBox.critical(self, "Port name format", "If the segment size is not 0, the format must contain {1}, {segment0} or {segment1}")
             else:
                 settings["port_segment_size"] = port_segment_size
 

--- a/gns3/modules/virtualbox/ui/virtualbox_vm_configuration_page.ui
+++ b/gns3/modules/virtualbox/ui/virtualbox_vm_configuration_page.ui
@@ -256,6 +256,9 @@
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="uiPortNameFormatLabel">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;{0} - the port number, from 0 to the number of adapters-1.&lt;/p&gt;&lt;p&gt;{1} - the segment number, from 0 to the number of segments-1.&lt;/p&gt;&lt;p&gt;{port0} - named alias for {0}.&lt;/p&gt;&lt;p&gt;{port1} - the port number, from 1 to the number of adapters.&lt;/p&gt;&lt;p&gt;{segment0} - named alias for {1}.&lt;/p&gt;&lt;p&gt;{segment1} - the segment number, from 1 to the number of segments.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
          <property name="text">
           <string>Name format:</string>
          </property>

--- a/gns3/modules/virtualbox/ui/virtualbox_vm_configuration_page_ui.py
+++ b/gns3/modules/virtualbox/ui/virtualbox_vm_configuration_page_ui.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/cetko/projects/gns3/gns3-gui/gns3/modules/virtualbox/ui/virtualbox_vm_configuration_page.ui'
+# Form implementation generated from reading ui file 'D:\Vasko\PyCharmProjects\gns3-gui\gns3\modules\virtualbox\ui\virtualbox_vm_configuration_page.ui'
 #
-# Created by: PyQt5 UI code generator 5.4.2
+# Created by: PyQt5 UI code generator 5.5.1
 #
 # WARNING! All changes made in this file will be lost!
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-
 class Ui_virtualBoxVMConfigPageWidget(object):
-
     def setupUi(self, virtualBoxVMConfigPageWidget):
         virtualBoxVMConfigPageWidget.setObjectName("virtualBoxVMConfigPageWidget")
         virtualBoxVMConfigPageWidget.resize(510, 463)
@@ -170,6 +168,8 @@ class Ui_virtualBoxVMConfigPageWidget(object):
         self.label.setText(_translate("virtualBoxVMConfigPageWidget", "Type:"))
         self.uiUseAnyAdapterCheckBox.setText(_translate("virtualBoxVMConfigPageWidget", "Allow GNS3 to use any configured VirtualBox adapter"))
         self.uiPortSegmentSizeLabel.setText(_translate("virtualBoxVMConfigPageWidget", "Segment size:"))
+        self.uiPortNameFormatLabel.setToolTip(_translate("virtualBoxVMConfigPageWidget", "<html><head/><body><p>{0} - the port number, from 0 to the number of adapters-1.</p><p>{1} - the segment number, from 0 to the number of segments-1.</p><p>{port0} - named alias for {0}.</p><p>{port1} - the port number, from 1 to the number of adapters.</p><p>{segment0} - named alias for {1}.</p><p>{segment1} - the segment number, from 1 to the number of segments.</p></body></html>"))
         self.uiPortNameFormatLabel.setText(_translate("virtualBoxVMConfigPageWidget", "Name format:"))
         self.uiFirstPortNameLabel.setText(_translate("virtualBoxVMConfigPageWidget", "First port name:"))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab_2), _translate("virtualBoxVMConfigPageWidget", "Network"))
+

--- a/gns3/modules/virtualbox/virtualbox_vm.py
+++ b/gns3/modules/virtualbox/virtualbox_vm.py
@@ -78,7 +78,14 @@ class VirtualBoxVM(VM):
             if self._first_port_name and adapter_number == 0:
                 port_name = self._first_port_name
             else:
-                port_name = self._port_name_format.format(interface_number, segment_number)
+                port_name = self._port_name_format.format(
+                    interface_number,
+                    segment_number,
+                    port0 = interface_number,
+                    port1 = 1 + interface_number,
+                    segment0 = segment_number,
+                    segment1 = 1 + segment_number
+                )
                 interface_number += 1
                 if self._port_segment_size and interface_number % self._port_segment_size == 0:
                     segment_number += 1

--- a/gns3/modules/vmware/pages/vmware_vm_configuration_page.py
+++ b/gns3/modules/vmware/pages/vmware_vm_configuration_page.py
@@ -183,14 +183,14 @@ class VMwareVMConfigurationPage(QtWidgets.QWidget, Ui_VMwareVMConfigPageWidget):
 
             settings["category"] = self.uiCategoryComboBox.itemData(self.uiCategoryComboBox.currentIndex())
             port_name_format = self.uiPortNameFormatLineEdit.text()
-            if '{0}' not in port_name_format:
-                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain at least {0}")
+            if '{0}' not in port_name_format and '{port0}' not in port_name_format and '{port1}' not in port_name_format:
+                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain at least {0}, {port0} or {port1}")
             else:
                 settings["port_name_format"] = self.uiPortNameFormatLineEdit.text()
 
             port_segment_size = self.uiPortSegmentSizeSpinBox.value()
-            if port_segment_size and '{1}' not in port_name_format:
-                QtWidgets.QMessageBox.critical(self, "Port name format", "The format must contain {1} if the segment size is not 0")
+            if port_segment_size and '{1}' not in port_name_format and '{segment0}' not in port_name_format and '{segment1}' not in port_name_format:
+                QtWidgets.QMessageBox.critical(self, "Port name format", "If the segment size is not 0, the format must contain {1}, {segment0} or {segment1}")
             else:
                 settings["port_segment_size"] = port_segment_size
 

--- a/gns3/modules/vmware/ui/vmware_vm_configuration_page.ui
+++ b/gns3/modules/vmware/ui/vmware_vm_configuration_page.ui
@@ -145,6 +145,9 @@
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="uiPortNameFormatLabel">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;{0} - the port number, from 0 to the number of adapters-1.&lt;/p&gt;&lt;p&gt;{1} - the segment number, from 0 to the number of segments-1.&lt;/p&gt;&lt;p&gt;{port0} - named alias for {0}.&lt;/p&gt;&lt;p&gt;{port1} - the port number, from 1 to the number of adapters.&lt;/p&gt;&lt;p&gt;{segment0} - named alias for {1}.&lt;/p&gt;&lt;p&gt;{segment1} - the segment number, from 1 to the number of segments.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
          <property name="text">
           <string>Name format:</string>
          </property>

--- a/gns3/modules/vmware/ui/vmware_vm_configuration_page_ui.py
+++ b/gns3/modules/vmware/ui/vmware_vm_configuration_page_ui.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/cetko/projects/gns3/gns3-gui/gns3/modules/vmware/ui/vmware_vm_configuration_page.ui'
+# Form implementation generated from reading ui file 'D:\Vasko\PyCharmProjects\gns3-gui\gns3\modules\vmware\ui\vmware_vm_configuration_page.ui'
 #
-# Created by: PyQt5 UI code generator 5.5
+# Created by: PyQt5 UI code generator 5.5.1
 #
 # WARNING! All changes made in this file will be lost!
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-
 class Ui_VMwareVMConfigPageWidget(object):
-
     def setupUi(self, VMwareVMConfigPageWidget):
         VMwareVMConfigPageWidget.setObjectName("VMwareVMConfigPageWidget")
         VMwareVMConfigPageWidget.resize(494, 381)
@@ -143,6 +141,7 @@ class Ui_VMwareVMConfigPageWidget(object):
         self.uiSymbolToolButton.setText(_translate("VMwareVMConfigPageWidget", "&Browse..."))
         self.uiCategoryLabel.setText(_translate("VMwareVMConfigPageWidget", "Category:"))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab), _translate("VMwareVMConfigPageWidget", "General settings"))
+        self.uiPortNameFormatLabel.setToolTip(_translate("VMwareVMConfigPageWidget", "<html><head/><body><p>{0} - the port number, from 0 to the number of adapters-1.</p><p>{1} - the segment number, from 0 to the number of segments-1.</p><p>{port0} - named alias for {0}.</p><p>{port1} - the port number, from 1 to the number of adapters.</p><p>{segment0} - named alias for {1}.</p><p>{segment1} - the segment number, from 1 to the number of segments.</p></body></html>"))
         self.uiPortNameFormatLabel.setText(_translate("VMwareVMConfigPageWidget", "Name format:"))
         self.uiPortSegmentSizeLabel.setText(_translate("VMwareVMConfigPageWidget", "Segment size:"))
         self.uiAdaptersLabel.setText(_translate("VMwareVMConfigPageWidget", "Adapters:"))
@@ -151,3 +150,4 @@ class Ui_VMwareVMConfigPageWidget(object):
         self.uiFirstPortNameLabel.setText(_translate("VMwareVMConfigPageWidget", "First port name:"))
         self.uiUseUbridgeCheckBox.setText(_translate("VMwareVMConfigPageWidget", "Use uBridge for network connections"))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab_2), _translate("VMwareVMConfigPageWidget", "Network"))
+

--- a/gns3/modules/vmware/vmware_vm.py
+++ b/gns3/modules/vmware/vmware_vm.py
@@ -81,7 +81,14 @@ class VMwareVM(VM):
             if self._first_port_name and adapter_number == 0:
                 port_name = self._first_port_name
             else:
-                port_name = self._port_name_format.format(interface_number, segment_number)
+                port_name = self._port_name_format.format(
+                    interface_number,
+                    segment_number,
+                    port0 = interface_number,
+                    port1 = 1 + interface_number,
+                    segment0 = segment_number,
+                    segment1 = 1 + segment_number
+                )
                 interface_number += 1
                 if self._port_segment_size and interface_number % self._port_segment_size == 0:
                     segment_number += 1


### PR DESCRIPTION
In addition to being a more "natural" naming scheme, some routers actually use that scheme for their default interface names (case in point: MikroTik RouterOS, which uses ether1, ether2, etc.).

This PR adds such a support for Qemu, VirtualBox and VMware, while also making sure that using EITHER one is allowed (and not just ```{0}```).

Largely for BC reasons, the numeric placeholders are still the same, but new named variables (```{port0}```, ```{port1}```, ```{segment0}```, ```{segment1}```) are added.