### PR TITLE
Disk interfaces on Qemu appliances

### DIFF
--- a/gns3/registry/config.py
+++ b/gns3/registry/config.py
@@ -229,6 +229,11 @@ class Config:
         new_config.setdefault("initrd", "")
         new_config.setdefault("kernel_image", "")
 
+        new_config["hda_disk_interface"] = appliance_config["qemu"].get("hda_disk_interface", "ide")
+        new_config["hdb_disk_interface"] = appliance_config["qemu"].get("hdb_disk_interface", "ide")
+        new_config["hdc_disk_interface"] = appliance_config["qemu"].get("hdc_disk_interface", "ide")
+        new_config["hdd_disk_interface"] = appliance_config["qemu"].get("hdd_disk_interface", "ide")
+
         new_config["kernel_command_line"] = appliance_config["qemu"].get("kernel_command_line", "")
 
         new_config["qemu_path"] = "qemu-system-{}".format(appliance_config["qemu"]["arch"])


### PR DESCRIPTION
This PR adds the ability of .gns3a files to optionally specify desired disk interfaces for each HDD drive.

If present, they must be part of the qmu section, e.g.
````json
    "qemu": {
        "arch": "x86_64",
        "adapter_type": "vmxnet3",
        "hda_disk_interface": "virtio",
        "boot_priority": "c",
        "ram": 64,
        "options": "-nographic",
        "console_type": "telnet",
        "adapters": 2
    }
```

Defaults to "ide" when not present, which is what's ultimately used currently anyway.