### PR TITLE
Fix only one console work for OSX

### DIFF
--- a/gns3/settings.py
+++ b/gns3/settings.py
@@ -69,11 +69,7 @@ elif sys.platform.startswith("darwin"):
     PRECONFIGURED_TELNET_CONSOLE_COMMANDS = {
         'Terminal': "osascript -e 'tell application \"Terminal\"'"
                     " -e 'activate'"
-                    " -e 'set _tab to do script \"echo -n -e \\\"\\\\033]0;%d\\\\007\\\"; clear; telnet %h %p ; exit\"'"
-                    " -e 'delay 1'"
-                    " -e 'repeat while _tab exists'"
-                    " -e 'delay 1'"
-                    " -e 'end repeat'"
+                    " -e 'do script \"echo -n -e \\\"\\\\033]0;%d\\\\007\\\"; clear; telnet %h %p ; exit\"'"
                     " -e 'end tell'",
         'Terminal tabbed (experimental)': "osascript -e 'tell application \"Terminal\"'"
                     " -e 'activate'"
@@ -100,10 +96,6 @@ elif sys.platform.startswith("darwin"):
                  " -e '  set s to (make new session at the end of sessions)'"
                  " -e '  tell s'"
                  " -e '    exec command (\"telnet %h %p\")'"
-                 " -e '    delay 1'"
-                 " -e '    repeat while s exists'"
-                 " -e '      delay 1'"
-                 " -e '    end repeat'"
                  " -e '  end tell'"
                  " -e 'end tell'"
                  " -e 'end tell'",
@@ -119,10 +111,6 @@ elif sys.platform.startswith("darwin"):
                     " -e '    set s to current session'"
                     " -e '    tell s'"
                     " -e '        write text \"telnet %h %p\"'"
-                    " -e '        delay 1'"
-                    " -e '        repeat while s exists'"
-                    " -e '            delay 1'"
-                    " -e '        end repeat'"
                     " -e '    end tell'"
                     " -e 'end tell'"
                     " -e 'end tell'",


### PR DESCRIPTION
In previous releases we got race conditions issues with
the OSX console due to the usage of Apple Script.

Problem. How to fix this situation for all users. Should
we reset terminal preferences for all OSX users coming from version
older than 1.4.1 ?

Fix #941