### PR TITLE
Reset the telnet command on Mac

### DIFF
--- a/gns3/local_config.py
+++ b/gns3/local_config.py
@@ -27,7 +27,6 @@ from .qt import QtCore
 from .version import __version__
 from .utils import parse_version
 
-
 import logging
 log = logging.getLogger(__name__)
 
@@ -146,6 +145,14 @@ class LocalConfig(QtCore.QObject):
                 main_window = self._settings.get("MainWindow", {})
                 main_window["hide_getting_started_dialog"] = self._settings["GUI"].get("hide_getting_started_dialog", False)
                 self._settings["MainWindow"] = main_window
+
+        if "version" not in self._settings or parse_version(self._settings["version"]) < parse_version("1.4.1dev2"):
+            if sys.platform.startswith("darwin"):
+                from .settings import PRECONFIGURED_TELNET_CONSOLE_COMMANDS, DEFAULT_TELNET_CONSOLE_COMMAND
+
+                if self._settings["MainWindow"]["telnet_console_command"] not in PRECONFIGURED_TELNET_CONSOLE_COMMANDS.values():
+                    self._settings["MainWindow"]["telnet_console_command"] = DEFAULT_TELNET_CONSOLE_COMMAND
+
 
     def _readConfig(self, config_path):
         """

--- a/gns3/version.py
+++ b/gns3/version.py
@@ -25,5 +25,5 @@ or negative for a release candidate or beta (after the base version
 number has been incremented)
 """
 
-__version__ = "1.4.1dev1"
+__version__ = "1.4.1dev2"
 __version_info__ = (1, 4, 1, -99)


### PR DESCRIPTION
Following the issue #942

It's the easiest way to do it. But we can not interact
with the user at this step because the Qt is not yet started.
This mean during the upgrade the command is reset to the standard.

Even if some users could be disapointed it's positive for most user.
Because for most user the current settings is broke. And if someone
has change something he know how to configure it again (for example
switching to iTerm). If we don't do that I think the bug will remain
for years.