### PR TITLE
Fix inversion of port label when loading a topology

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -297,12 +297,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
         # Multi-link management
         #
         # multi is the offset of the link
-        # +------+       multi = -1    Link 3  +-------+
+        # +------+       multi = -1    Link 2  +-------+
         # |      +-----------------------------+       |
         # |  R1  |                             |   R2  |
         # |      |        multi = 0    Link 1  |       |
         # |      +-----------------------------+       |
-        # |      |        multi = 1    Link 2  |       |
+        # |      |        multi = 1    Link 3  |       |
         # +------+-----------------------------+-------+
 
         if source_item == destination_item:
@@ -324,9 +324,6 @@ class GraphicsView(QtWidgets.QGraphicsView):
             multi = multi / 2
         else:
             multi = math.ceil(float(multi) / 2) * -1
-
-        print(multi)
-
 
         if link.sourcePort().linkType() == "Serial" or (source_port.isStub() and link.destinationPort().linkType() == "Serial"):
             link_item = SerialLinkItem(source_item, source_port, destination_item, destination_port, link, multilink=multi)

--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -22,6 +22,7 @@ Graphical view on the scene where items are drawn.
 import logging
 import os
 import pickle
+import math
 
 from .qt import QtCore, QtGui, QtSvg, QtNetwork, QtWidgets, qpartial
 from .servers import Servers
@@ -293,36 +294,39 @@ class GraphicsView(QtWidgets.QGraphicsView):
             self.deleteLinkSlot(link_id)
             return
 
-        # ugly multi-link management
-        # FIXME: taken from old GNS3 and has a bug!
-        multi = 0
-        d1 = 0
-        d2 = 1
-        link_items = source_item.links()
-        for link_item in link_items:
-            if link_item.destinationItem().node().id() == destination_item.node().id():
-                d1 += 1
-            if link_item.sourceItem().node().id() == destination_item.node().id():
-                d2 += 1
-
-        if len(link_items) > 0:
-            if d2 - d1 == 2:
-                source_port, destination_port = destination_port, source_port
-                source_item, destination_item = destination_item, source_item
-                multi = d1 + 1
-            elif d1 >= d2:
-                source_port, destination_port = destination_port, source_port
-                source_item, destination_item = destination_item, source_item
-                multi = d2
-            else:
-                multi = d1
-
-        # MAX 7 links on the scene between 2 nodes
-        if multi > 3:
-            multi = 0
+        # Multi-link management
+        #
+        # multi is the offset of the link
+        # +------+       multi = -1    Link 3  +-------+
+        # |      +-----------------------------+       |
+        # |  R1  |                             |   R2  |
+        # |      |        multi = 0    Link 1  |       |
+        # |      +-----------------------------+       |
+        # |      |        multi = 1    Link 2  |       |
+        # +------+-----------------------------+-------+
 
         if source_item == destination_item:
             multi = 0
+        else:
+            multi = 0
+            link_items = source_item.links()
+            for link_item in link_items:
+                if link_item.destinationItem().node().id() == destination_item.node().id():
+                    multi += 1
+                if link_item.sourceItem().node().id() == destination_item.node().id():
+                    multi += 1
+
+        # MAX 7 links on the scene between 2 nodes
+        if multi > 7:
+            multi = 0
+        # Pair item represent the bottom links
+        elif multi % 2 == 0:
+            multi = multi / 2
+        else:
+            multi = math.ceil(float(multi) / 2) * -1
+
+        print(multi)
+
 
         if link.sourcePort().linkType() == "Serial" or (source_port.isStub() and link.destinationPort().linkType() == "Serial"):
             link_item = SerialLinkItem(source_item, source_port, destination_item, destination_port, link, multilink=multi)

--- a/gns3/serial_console.py
+++ b/gns3/serial_console.py
@@ -20,6 +20,7 @@ Functions to start external serial console terminals.
 """
 
 import sys
+import os
 import shlex
 import subprocess
 from .main_window import MainWindow
@@ -54,7 +55,7 @@ def serialConsole(vmname, pipe_path):
         else:
             # use arguments on other platforms
             args = shlex.split(command)
-            subprocess.Popen(args)
+            subprocess.Popen(args, env=os.environ)
     except (OSError, subprocess.SubprocessError) as e:
         log.warning('could not start serial console "{}": {}'.format(command, e))
         raise

--- a/gns3/vnc_console.py
+++ b/gns3/vnc_console.py
@@ -20,6 +20,7 @@ Functions to start VNC console programs.
 """
 
 import sys
+import os
 import shlex
 import subprocess
 from .main_window import MainWindow
@@ -52,7 +53,7 @@ def vncConsole(host, port):
         else:
             # use arguments on other platforms
             args = shlex.split(command)
-            subprocess.Popen(args)
+            subprocess.Popen(args, env=os.environ)
     except (OSError, ValueError, subprocess.SubprocessError) as e:
         log.warning('could not start VNC program "{}": {}'.format(command, e))
         raise


### PR DESCRIPTION
This PR rewrite the way multi link are created and avoid
to invert their directions.

Fix #954