### PR TITLE
If the server doesn't exists in settings we ask to replace it

### DIFF
--- a/gns3/servers.py
+++ b/gns3/servers.py
@@ -687,9 +687,27 @@ class Servers(QtCore.QObject):
         client = HTTPClient(settings, network_manager)
         return client
 
+    def foundRemoteServer(self, protocol, host, port, user, settings={}):
+        """
+        Search a remote server.
+
+        :param protocol: server protocol (http/https)
+        :param host: host address
+        :param port: port
+        :param user: the username
+        :param settings: Additional settings
+
+        :returns: remote server (HTTPClient instance). Return None if it's doesn't exists
+        """
+        url = getNetworkUrl(protocol, host, port, user, settings)
+        for server in self._remote_servers.values():
+            if server.url() == url:
+                return server
+        return None
+
     def getRemoteServer(self, protocol, host, port, user, settings={}):
         """
-        Gets a remote server.
+        Gets a remote server. Create a new one if it doesn't exists
 
         :param protocol: server protocol (http/https)
         :param host: host address
@@ -700,11 +718,9 @@ class Servers(QtCore.QObject):
         :returns: remote server (HTTPClient instance)
         """
 
-        url = getNetworkUrl(protocol, host, port, user, settings)
-        for server in self._remote_servers.values():
-            if server.url() == url:
-                return server
-
+        server = self.foundRemoteServer(protocol, host, port, user, settings)
+        if server:
+            return server
         settings['user'] = user
         settings['protocol'] = protocol
         settings['host'] = host

--- a/gns3/servers.py
+++ b/gns3/servers.py
@@ -687,7 +687,7 @@ class Servers(QtCore.QObject):
         client = HTTPClient(settings, network_manager)
         return client
 
-    def foundRemoteServer(self, protocol, host, port, user, settings={}):
+    def findRemoteServer(self, protocol, host, port, user, settings={}):
         """
         Search a remote server.
 
@@ -697,7 +697,7 @@ class Servers(QtCore.QObject):
         :param user: the username
         :param settings: Additional settings
 
-        :returns: remote server (HTTPClient instance). Return None if it's doesn't exists
+        :returns: remote server (HTTPClient instance). Returns None if it doesn't exist.
         """
         url = getNetworkUrl(protocol, host, port, user, settings)
         for server in self._remote_servers.values():
@@ -718,7 +718,7 @@ class Servers(QtCore.QObject):
         :returns: remote server (HTTPClient instance)
         """
 
-        server = self.foundRemoteServer(protocol, host, port, user, settings)
+        server = self.findRemoteServer(protocol, host, port, user, settings)
         if server:
             return server
         settings['user'] = user

--- a/gns3/topology.py
+++ b/gns3/topology.py
@@ -42,6 +42,7 @@ from .servers import Servers
 from .modules import MODULES
 from .modules.module_error import ModuleError
 from .utils.message_box import MessageBox
+from .utils.server_select import server_select
 from .version import __version__
 from .topology_check import getTopologyValidationErrors
 
@@ -672,7 +673,17 @@ class Topology:
                     topology_server.pop("local", False)
 
                     server_id = topology_server.pop("id")
-                    self._servers[server_id] = server_manager.getRemoteServer(protocol, host, port, user, topology_server)
+                    self._servers[server_id] = server_manager.foundRemoteServer(protocol, host, port, user, topology_server)
+
+                    reply = QtWidgets.QMessageBox.warning(main_window, "Load topology", "The server {}://{}:{} doesn't exists in your settings do you want to choose a different?\nWe recommend to backup the topology before.".format(protocol, host, port), QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+                    if reply == QtWidgets.QMessageBox.Yes:
+                        self._servers[server_id] = server_select(main_window)
+
+                    if self._servers[server_id] is None:
+                        # The user has not change the server we create the server from the topology
+                        self._servers[server_id] = server_manager.getRemoteServer(protocol, host, port, user, topology_server)
+
+
 
         # nodes
         self._load_old_topology = False

--- a/gns3/topology.py
+++ b/gns3/topology.py
@@ -673,17 +673,19 @@ class Topology:
                     topology_server.pop("local", False)
 
                     server_id = topology_server.pop("id")
-                    self._servers[server_id] = server_manager.foundRemoteServer(protocol, host, port, user, topology_server)
+                    self._servers[server_id] = server_manager.findRemoteServer(protocol, host, port, user, topology_server)
 
-                    reply = QtWidgets.QMessageBox.warning(main_window, "Load topology", "The server {}://{}:{} doesn't exists in your settings do you want to choose a different?\nWe recommend to backup the topology before.".format(protocol, host, port), QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+                    reply = QtWidgets.QMessageBox.warning(main_window,
+                                                          "Remote server not found",
+                                                          "Remote server {}://{}:{} doesn't exist in your preferences, do you want to select another server?\n\nIt is recommended to backup your project first.".format(protocol, host, port),
+                                                          QtWidgets.QMessageBox.Yes,
+                                                          QtWidgets.QMessageBox.No)
                     if reply == QtWidgets.QMessageBox.Yes:
                         self._servers[server_id] = server_select(main_window)
 
                     if self._servers[server_id] is None:
-                        # The user has not change the server we create the server from the topology
+                        # The user has not changed the server, let's create the server from the topology
                         self._servers[server_id] = server_manager.getRemoteServer(protocol, host, port, user, topology_server)
-
-
 
         # nodes
         self._load_old_topology = False

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -106,6 +106,21 @@ def testServers():
     assert len(servers.servers()) == 2
 
 
+def test_foundRemoteServer():
+    servers = Servers.instance()
+    # Create a server
+    http_server = servers.getRemoteServer("http", "localhost", 3080, None)
+
+    http_server = servers.foundRemoteServer("http", "localhost", 3080, None)
+    assert http_server.protocol() == "http"
+    assert http_server.host() == "localhost"
+    assert http_server.port() == 3080
+    assert http_server.user() is None
+
+    http_server = servers.foundRemoteServer("http", "localhost", 4242, None)
+    assert http_server is None
+
+
 def test_getRemoteServer():
     servers = Servers.instance()
     http_server = servers.getRemoteServer("http", "localhost", 3080, None)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -24,6 +24,7 @@ from gns3.project import Project
 from gns3.version import __version__
 from gns3.items.pixmap_image_item import PixmapImageItem
 import gns3.main_window
+import gns3.qt
 
 
 def test_topology_init():
@@ -371,6 +372,133 @@ def test_load(project, monkeypatch, main_window, tmpdir):
     assert len(topology.nodes()) == 2
     assert len(topology._node_to_links_mapping) == 2
     assert topology.getNode(1).initialized()
+    assert topology.getNode(1).server() is not None
+    assert topology.getNode(2).initialized()
+    assert main_window.uiGraphicsView.addLink.called
+
+
+def test_load_invalid_server(project, monkeypatch, main_window, tmpdir):
+
+    topo = {
+        "project_id": project.id(),
+        "auto_start": False,
+        "name": "twovpcs",
+        "topology": {
+            "links": [
+                {
+                    "description": "Link from VPCS 1 port Ethernet0 to VPCS 2 port Ethernet0",
+                    "destination_node_id": 2,
+                    "destination_port_id": 2,
+                    "id": 1,
+                    "source_node_id": 1,
+                    "source_port_id": 1
+                }
+            ],
+            "nodes": [
+                {
+                    "description": "VPCS device",
+                    "id": 1,
+                    "label": {
+                        "color": "#000000",
+                        "font": "TypeWriter,10,-1,5,75,0,0,0,0,0",
+                        "text": "VPCS 1",
+                        "x": 10.75,
+                        "y": -25.0
+                    },
+                    "ports": [
+                        {
+                            "description": "connected to VPCS 2 on port Ethernet0",
+                            "id": 1,
+                            "link_id": 1,
+                            "name": "Ethernet0",
+                            "nio": "NIO_UDP",
+                            "port_number": 0,
+                            "adapter_number": 0
+                        }
+                    ],
+                    "properties": {
+                        "console": 4501,
+                        "name": "VPCS 1",
+                        "script_file": "startup.vpc"
+                    },
+                    "server_id": 1,
+                    "type": "VPCSDevice",
+                    "vpcs_id": 1,
+                    "vm_id": "2b5476de-6e79-4eb5-b0eb-8c54c7821cb8",
+                    "x": -349.5,
+                    "y": -206.5
+                },
+                {
+                    "description": "VPCS device",
+                    "id": 2,
+                    "label": {
+                        "color": "#000000",
+                        "font": "TypeWriter,10,-1,5,75,0,0,0,0,0",
+                        "text": "VPCS 2",
+                        "x": 10.75,
+                        "y": -25.0
+                    },
+                    "ports": [
+                        {
+                            "description": "connected to VPCS 1 on port Ethernet0",
+                            "id": 2,
+                            "link_id": 1,
+                            "name": "Ethernet0",
+                            "nio": "NIO_UDP",
+                            "port_number": 0
+                        }
+                    ],
+                    "properties": {
+                        "console": 4502,
+                        "name": "VPCS 2",
+                        "script_file": "startup.vpc"
+                    },
+                    "server_id": 1,
+                    "type": "VPCSDevice",
+                    "vm_id": "2b5476de-6e79-4eb5-b0eb-8c54c7821cba",
+                    "vpcs_id": 2,
+                    "x": 69.5,
+                    "y": -190.5
+                }
+            ],
+            "servers": [
+                {
+                    "host": "127.0.0.1",
+                    "id": 1,
+                    "local": False,
+                    "port": 3081
+                }
+            ]
+        },
+        "type": "topology",
+        "version": "1.3.0"
+    }
+
+    monkeypatch.setattr('gns3.main_window.MainWindow.instance', lambda: main_window)
+
+    # We return an uuid for each HTTP post
+    def http_loader(self, method, path, callback, body={}, **kwargs):
+        if path == "/projects":
+            callback({"project_id": uuid.uuid4(), "path": str(tmpdir)})
+        elif path[-14:] == "/notifications":
+            pass
+        else:
+            callback({"vm_id": uuid.uuid4()})
+
+    monkeypatch.setattr("gns3.http_client.HTTPClient.createHTTPQuery", http_loader)
+
+    monkeypatch.setattr("gns3.http_client.HTTPClient.connected", lambda self: True)
+
+    topology = Topology()
+    topology.project = project
+    with patch("gns3.qt.QtWidgets.QMessageBox.warning", return_value=gns3.qt.QtWidgets.QMessageBox.Yes):
+        topology._load(topo)
+
+    assert topology._project.id() == project.id()
+    assert len(topology.nodes()) == 2
+    assert len(topology._node_to_links_mapping) == 2
+    assert topology.getNode(1).initialized()
+    assert topology.getNode(1).server() is not None
     assert topology.getNode(2).initialized()
     assert main_window.uiGraphicsView.addLink.called
 


### PR DESCRIPTION
When we load a topology we check if the server exist in our settings otherwise we ask the user to select a new server.

The user can refuse that and we will continue to create the server
from the topology. It's use the standard server list dialog to keep
code simple.

![capture d ecran 2016-03-29 a 10 02 21](https://cloud.githubusercontent.com/assets/345437/14101624/e654686c-f595-11e5-912b-31b8e2c837c2.png)

![capture d ecran 2016-03-29 a 10 02 28](https://cloud.githubusercontent.com/assets/345437/14101627/ed9fe38a-f595-11e5-8581-15171f3cc19e.png)


Fix #1144