### PR TITLE
Always init the GNS3 VM

### DIFF
--- a/gns3/main_window.py
+++ b/gns3/main_window.py
@@ -1168,11 +1168,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         servers = Servers.instance()
         # start the GNS3 VM
         gns3_vm = GNS3VM.instance()
-        if gns3_vm.autoStart() and not gns3_vm.isRunning():
+        if not gns3_vm.isRunning():
             servers.initVMServer()
             if gns3_vm.isRemote():
                 gns3_vm.setRunning(True)
-            else:
+            elif gns3_vm.autoStart():
                 worker = WaitForVMWorker()
                 progress_dialog = ProgressDialog(worker, "GNS3 VM", "Starting the GNS3 VM...", "Cancel", busy=True, parent=self, delay=5)
                 progress_dialog.show()


### PR DESCRIPTION
I'm not sure at 100% but I think we need to
initialize the VM for all cases even we don't need the
autostart

Fix #1215