### PR TITLE
Shutdown local server via controller

### DIFF
--- a/gns3/utils/http.py
+++ b/gns3/utils/http.py
@@ -63,3 +63,4 @@ def getSynchronous(host, port, endpoint, timeout=2, user=None, password=None):
     except (OSError, http.client.BadStatusLine, ValueError) as e:
         log.debug("Error during get on {}:{}: {}".format(host, port, e))
     return 0, None
+


### PR DESCRIPTION
Fix #1191

I added a Progress Dialog. This allow to use a Qt sleep for waiting the process instead of Python timeout. The issue with Python timeout is the HTTP query send to the server for asking it to shutdown will not close until Qt can read it this block the whole process.