### PR TITLE
A button to open the file browser with the configuration file location

### DIFF
--- a/gns3/pages/general_preferences_page.py
+++ b/gns3/pages/general_preferences_page.py
@@ -60,6 +60,7 @@ class GeneralPreferencesPage(QtWidgets.QWidget, Ui_GeneralPreferencesPageWidget)
         self.uiVNCConsolePreconfiguredCommandPushButton.clicked.connect(self._vncConsolePreconfiguredCommandSlot)
         self.uiDefaultLabelFontPushButton.clicked.connect(self._setDefaultLabelFontSlot)
         self.uiDefaultLabelColorPushButton.clicked.connect(self._setDefaultLabelColorSlot)
+        self.uiBrowseConfigurationPushButton.clicked.connect(self._browseConfigurationDirectorySlot)
         self._default_label_color = QtGui.QColor(QtCore.Qt.black)
         self.uiStyleComboBox.addItems(STYLES)
 
@@ -191,6 +192,12 @@ class GeneralPreferencesPage(QtWidgets.QWidget, Ui_GeneralPreferencesPageWidget)
         # QtWidgets.QApplication.quit()
         LocalConfig.instance().setConfigFilePath(configuration_file_path)
         self._preferences_dialog.reject()
+
+    def _browseConfigurationDirectorySlot(self):
+        """
+        Slot to open a file browser into the configuration directory
+        """
+        QtGui.QDesktopServices.openUrl(QtCore.QUrl("file://" + LocalConfig.configDirectory()))
 
     def _exportConfigurationFileSlot(self):
         """

--- a/gns3/ui/general_preferences_page.ui
+++ b/gns3/ui/general_preferences_page.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>527</width>
-    <height>541</height>
+    <height>568</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -193,6 +193,13 @@
              <widget class="QPushButton" name="uiExportConfigurationFilePushButton">
               <property name="text">
                <string>&amp;Export</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="uiBrowseConfigurationPushButton">
+              <property name="text">
+               <string>Browse configuration directory</string>
               </property>
              </widget>
             </item>

--- a/gns3/ui/general_preferences_page.ui
+++ b/gns3/ui/general_preferences_page.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>527</width>
+    <width>529</width>
     <height>568</height>
    </rect>
   </property>

--- a/gns3/ui/general_preferences_page_ui.py
+++ b/gns3/ui/general_preferences_page_ui.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/grossmj/PycharmProjects/gns3-gui/gns3/ui/general_preferences_page.ui'
+# Form implementation generated from reading ui file '/Users/noplay/code/gns3/gns3-gui/gns3/ui/general_preferences_page.ui'
 #
-# Created: Thu May  5 18:39:32 2016
-#      by: PyQt5 UI code generator 5.2.1
+# Created by: PyQt5 UI code generator 5.6
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -12,7 +11,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 class Ui_GeneralPreferencesPageWidget(object):
     def setupUi(self, GeneralPreferencesPageWidget):
         GeneralPreferencesPageWidget.setObjectName("GeneralPreferencesPageWidget")
-        GeneralPreferencesPageWidget.resize(527, 541)
+        GeneralPreferencesPageWidget.resize(527, 568)
         self.verticalLayout = QtWidgets.QVBoxLayout(GeneralPreferencesPageWidget)
         self.verticalLayout.setObjectName("verticalLayout")
         self.uiMiscTabWidget = QtWidgets.QTabWidget(GeneralPreferencesPageWidget)
@@ -25,6 +24,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiGeneralTab = QtWidgets.QWidget()
         self.uiGeneralTab.setObjectName("uiGeneralTab")
         self.verticalLayout_4 = QtWidgets.QVBoxLayout(self.uiGeneralTab)
+        self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_4.setObjectName("verticalLayout_4")
         self.uiLocalPathsGroupBox = QtWidgets.QGroupBox(self.uiGeneralTab)
         self.uiLocalPathsGroupBox.setObjectName("uiLocalPathsGroupBox")
@@ -117,6 +117,9 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiExportConfigurationFilePushButton = QtWidgets.QPushButton(self.uiConfigurationFileGroupBox)
         self.uiExportConfigurationFilePushButton.setObjectName("uiExportConfigurationFilePushButton")
         self.horizontalLayout.addWidget(self.uiExportConfigurationFilePushButton)
+        self.uiBrowseConfigurationPushButton = QtWidgets.QPushButton(self.uiConfigurationFileGroupBox)
+        self.uiBrowseConfigurationPushButton.setObjectName("uiBrowseConfigurationPushButton")
+        self.horizontalLayout.addWidget(self.uiBrowseConfigurationPushButton)
         spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayout.addItem(spacerItem)
         self.gridLayout.addLayout(self.horizontalLayout, 1, 0, 1, 1)
@@ -130,6 +133,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiConsoleTab = QtWidgets.QWidget()
         self.uiConsoleTab.setObjectName("uiConsoleTab")
         self.verticalLayout_3 = QtWidgets.QVBoxLayout(self.uiConsoleTab)
+        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_3.setObjectName("verticalLayout_3")
         self.uiTelnetConsoleSettingsGroupBox = QtWidgets.QGroupBox(self.uiConsoleTab)
         self.uiTelnetConsoleSettingsGroupBox.setObjectName("uiTelnetConsoleSettingsGroupBox")
@@ -207,6 +211,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiVNCTab = QtWidgets.QWidget()
         self.uiVNCTab.setObjectName("uiVNCTab")
         self.verticalLayout_6 = QtWidgets.QVBoxLayout(self.uiVNCTab)
+        self.verticalLayout_6.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_6.setObjectName("verticalLayout_6")
         self.uiVNCConsoleSettingsGroupBox = QtWidgets.QGroupBox(self.uiVNCTab)
         self.uiVNCConsoleSettingsGroupBox.setObjectName("uiVNCConsoleSettingsGroupBox")
@@ -242,6 +247,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiSceneTab = QtWidgets.QWidget()
         self.uiSceneTab.setObjectName("uiSceneTab")
         self.gridLayout_8 = QtWidgets.QGridLayout(self.uiSceneTab)
+        self.gridLayout_8.setContentsMargins(0, 0, 0, 0)
         self.gridLayout_8.setObjectName("gridLayout_8")
         self.uiSceneWidthLabel = QtWidgets.QLabel(self.uiSceneTab)
         self.uiSceneWidthLabel.setObjectName("uiSceneWidthLabel")
@@ -305,6 +311,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.tab = QtWidgets.QWidget()
         self.tab.setObjectName("tab")
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.tab)
+        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.uiLaunchNewProjectDialogCheckBox = QtWidgets.QCheckBox(self.tab)
         self.uiLaunchNewProjectDialogCheckBox.setChecked(True)
@@ -374,6 +381,7 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiConfigurationFileGroupBox.setTitle(_translate("GeneralPreferencesPageWidget", "Configuration file"))
         self.uiImportConfigurationFilePushButton.setText(_translate("GeneralPreferencesPageWidget", "&Import"))
         self.uiExportConfigurationFilePushButton.setText(_translate("GeneralPreferencesPageWidget", "&Export"))
+        self.uiBrowseConfigurationPushButton.setText(_translate("GeneralPreferencesPageWidget", "Browse configuration directory"))
         self.uiConfigurationFileLabel.setText(_translate("GeneralPreferencesPageWidget", "Unknown location"))
         self.uiMiscTabWidget.setTabText(self.uiMiscTabWidget.indexOf(self.uiGeneralTab), _translate("GeneralPreferencesPageWidget", "General"))
         self.uiTelnetConsoleSettingsGroupBox.setTitle(_translate("GeneralPreferencesPageWidget", "Console settings"))

--- a/gns3/ui/general_preferences_page_ui.py
+++ b/gns3/ui/general_preferences_page_ui.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/Users/noplay/code/gns3/gns3-gui/gns3/ui/general_preferences_page.ui'
+# Form implementation generated from reading ui file '/home/grossmj/PycharmProjects/gns3-gui/gns3/ui/general_preferences_page.ui'
 #
-# Created by: PyQt5 UI code generator 5.6
+# Created: Tue Jun 21 21:50:52 2016
+#      by: PyQt5 UI code generator 5.2.1
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -11,7 +12,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 class Ui_GeneralPreferencesPageWidget(object):
     def setupUi(self, GeneralPreferencesPageWidget):
         GeneralPreferencesPageWidget.setObjectName("GeneralPreferencesPageWidget")
-        GeneralPreferencesPageWidget.resize(527, 568)
+        GeneralPreferencesPageWidget.resize(529, 568)
         self.verticalLayout = QtWidgets.QVBoxLayout(GeneralPreferencesPageWidget)
         self.verticalLayout.setObjectName("verticalLayout")
         self.uiMiscTabWidget = QtWidgets.QTabWidget(GeneralPreferencesPageWidget)
@@ -24,7 +25,6 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiGeneralTab = QtWidgets.QWidget()
         self.uiGeneralTab.setObjectName("uiGeneralTab")
         self.verticalLayout_4 = QtWidgets.QVBoxLayout(self.uiGeneralTab)
-        self.verticalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_4.setObjectName("verticalLayout_4")
         self.uiLocalPathsGroupBox = QtWidgets.QGroupBox(self.uiGeneralTab)
         self.uiLocalPathsGroupBox.setObjectName("uiLocalPathsGroupBox")
@@ -133,7 +133,6 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiConsoleTab = QtWidgets.QWidget()
         self.uiConsoleTab.setObjectName("uiConsoleTab")
         self.verticalLayout_3 = QtWidgets.QVBoxLayout(self.uiConsoleTab)
-        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_3.setObjectName("verticalLayout_3")
         self.uiTelnetConsoleSettingsGroupBox = QtWidgets.QGroupBox(self.uiConsoleTab)
         self.uiTelnetConsoleSettingsGroupBox.setObjectName("uiTelnetConsoleSettingsGroupBox")
@@ -211,7 +210,6 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiVNCTab = QtWidgets.QWidget()
         self.uiVNCTab.setObjectName("uiVNCTab")
         self.verticalLayout_6 = QtWidgets.QVBoxLayout(self.uiVNCTab)
-        self.verticalLayout_6.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_6.setObjectName("verticalLayout_6")
         self.uiVNCConsoleSettingsGroupBox = QtWidgets.QGroupBox(self.uiVNCTab)
         self.uiVNCConsoleSettingsGroupBox.setObjectName("uiVNCConsoleSettingsGroupBox")
@@ -247,7 +245,6 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.uiSceneTab = QtWidgets.QWidget()
         self.uiSceneTab.setObjectName("uiSceneTab")
         self.gridLayout_8 = QtWidgets.QGridLayout(self.uiSceneTab)
-        self.gridLayout_8.setContentsMargins(0, 0, 0, 0)
         self.gridLayout_8.setObjectName("gridLayout_8")
         self.uiSceneWidthLabel = QtWidgets.QLabel(self.uiSceneTab)
         self.uiSceneWidthLabel.setObjectName("uiSceneWidthLabel")
@@ -311,7 +308,6 @@ class Ui_GeneralPreferencesPageWidget(object):
         self.tab = QtWidgets.QWidget()
         self.tab.setObjectName("tab")
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.tab)
-        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.uiLaunchNewProjectDialogCheckBox = QtWidgets.QCheckBox(self.tab)
         self.uiLaunchNewProjectDialogCheckBox.setChecked(True)


### PR DESCRIPTION
This add in preferences a button to browse the configuration directory:
![image](https://cloud.githubusercontent.com/assets/345437/16189104/037ad83e-36d9-11e6-8ccf-01e6be5a30bb.png)

Fix #1321 