### PR TITLE
Protect one more method from deleted object

### DIFF
--- a/gns3/qt/__init__.py
+++ b/gns3/qt/__init__.py
@@ -27,6 +27,7 @@ import sys
 import sip
 import os
 import re
+import types
 import functools
 import inspect
 
@@ -208,3 +209,15 @@ def qpartial(func, *args, **kwargs):
 
     return functools.partial(func, *args, **kwargs)
 
+
+def qslot(func):
+    """
+    Decorated slot are protected against already destroyed element
+    in SIP but not in Python
+    """
+    def func_wrapper(*args, **kwargs):
+        if isinstance(func, types.MethodType):
+            if func is None or sip.isdeleted(func):
+                return lambda: True
+        return func(*args, **kwargs)
+    return func_wrapper


### PR DESCRIPTION
Always the same issue:
http://enki-editor.org/2014/08/23/Pyqt_mem_mgmt.html

I propose the creation of a qslot that we could use to decorate
all slot to protect them.

We can't wrap Signal or inherit from it :( So it's impossible to
do it for all slots without modifications everywhere.

Fix #1374