### PR TITLE
Support for profil settings

### DIFF
--- a/gns3/dialogs/export_debug_dialog.py
+++ b/gns3/dialogs/export_debug_dialog.py
@@ -55,7 +55,7 @@ class ExportDebugDialog(QtWidgets.QDialog, Ui_ExportDebugDialog):
         try:
             with ZipFile(path, 'w') as zip:
                 zip.writestr("debug.txt", self._getDebugData())
-                dir = LocalConfig.configDirectory()
+                dir = LocalConfig.instance().configDirectory()
                 for filename in os.listdir(dir):
                     path = os.path.join(dir, filename)
                     if os.path.isfile(path):

--- a/gns3/local_server.py
+++ b/gns3/local_server.py
@@ -87,7 +87,7 @@ class LocalServer():
         self._http_client = None
         self._local_server_path = ""
         self._local_server_process = None
-        self._config_directory = LocalConfig.configDirectory()
+        self._config_directory = LocalConfig.instance().configDirectory()
         self._pid_path = os.path.join(self._config_directory, "gns3_server.pid")
         self.localServerSettings()
         self._port = self._settings["port"]
@@ -373,6 +373,9 @@ class LocalServer():
         command = '"{executable}" --host={host} --port={port} --local --controller'.format(executable=path,
                                                                               host=host,
                                                                               port=port)
+
+        if LocalConfig.instance().profil():
+            command += " --profil {}".format(LocalConfig.instance().profil())
 
         if self._settings["allow_console_from_anywhere"]:
             # allow connections to console from remote addresses

--- a/gns3/main.py
+++ b/gns3/main.py
@@ -120,13 +120,11 @@ def main():
     parser.add_argument("--version", help="show the version", action="version", version=__version__)
     parser.add_argument("--debug", help="print out debug messages", action="store_true", default=False)
     parser.add_argument("--config", help="Configuration file")
+    parser.add_argument("--profil", help="Settings profil (blank will use default settings files)")
     options = parser.parse_args()
     exception_file_path = "exceptions.log"
 
-    if options.config:
-        LocalConfig.instance(config_file=options.config)
-    else:
-        LocalConfig.instance()
+    LocalConfig.instance(config_file=options.config, profil=options.profil)
 
     if hasattr(sys, "frozen"):
         # We add to the path where the OS search executable our binary location starting by GNS3
@@ -229,7 +227,7 @@ def main():
     app = Application(sys.argv)
 
     # save client logging info to a file
-    logfile = os.path.join(LocalConfig.configDirectory(), "gns3_gui.log")
+    logfile = os.path.join(LocalConfig.instance().configDirectory(), "gns3_gui.log")
 
     # on debug enable logging to stdout
     if options.debug:
@@ -238,7 +236,7 @@ def main():
         root_logger = init_logger(logging.INFO, logfile)
 
     # update the exception file path to have it in the same directory as the settings file.
-    exception_file_path = os.path.join(LocalConfig.configDirectory(), exception_file_path)
+    exception_file_path = os.path.join(LocalConfig.instance().configDirectory(), exception_file_path)
 
     global mainwindow
     startup_file = app.open_file_at_startup

--- a/gns3/pages/general_preferences_page.py
+++ b/gns3/pages/general_preferences_page.py
@@ -217,7 +217,7 @@ class GeneralPreferencesPage(QtWidgets.QWidget, Ui_GeneralPreferencesPageWidget)
         """
         Slot to open a file browser into the configuration directory
         """
-        QtGui.QDesktopServices.openUrl(QtCore.QUrl("file://" + LocalConfig.configDirectory()))
+        QtGui.QDesktopServices.openUrl(QtCore.QUrl("file://" + LocalConfig.instance().configDirectory()))
 
     def _exportConfigurationFileSlot(self):
         """


### PR DESCRIPTION
This PR add a --profil command line arguments.

If set a new set of settings will be create in
~/GNS3/profiles/PROFILENAME

Otherwise it's use the default location.

This allow to test settings without losing original settings.

Also with the correct GUI this allow to switch from local server to a remote (home / office). For #1280