### PR TITLE
Disallow opening a .gns3 on a remote server

### DIFF
--- a/gns3/main_window.py
+++ b/gns3/main_window.py
@@ -431,7 +431,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             self._appliance_wizard.show()
             self._appliance_wizard.exec_()
         elif path.endswith(".gns3"):
-            Topology.instance().loadProject(path)
+            if Controller.instance().isRemote():
+                QtWidgets.QMessageBox.critical(self, "Open project", "You can't open a .gns3 on a remote server, please use portable project")
+                return
+            else:
+                Topology.instance().loadProject(path)
         else:
             try:
                 extension = path.split('.')[1]

--- a/gns3/main_window.py
+++ b/gns3/main_window.py
@@ -418,7 +418,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             # Portable GNS3 project
             Topology.instance().importProject(path)
         elif path.endswith(".net"):
-            QtWidgets.QMessageBox.critical(self, "Open project", "Importing legacy project is not supported in 2.0.\nYou need to open it with GNS3 1.x in order to convert it or manually run the gns3 converter.")
+            QtWidgets.QMessageBox.critical(self, "Open project", "Importing legacy project is not supported in 2.0.\nYou must open it using GNS3 1.x in order to convert it or manually run the gns3 converter.")
             return
 
         elif path.endswith(".gns3appliance") or path.endswith(".gns3a"):
@@ -432,7 +432,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             self._appliance_wizard.exec_()
         elif path.endswith(".gns3"):
             if Controller.instance().isRemote():
-                QtWidgets.QMessageBox.critical(self, "Open project", "You can't open a .gns3 on a remote server, please use portable project")
+                QtWidgets.QMessageBox.critical(self, "Open project", "Cannot open a .gns3 file on a remote server, please use a portable project (.gns3p) instead")
                 return
             else:
                 Topology.instance().loadProject(path)


### PR DESCRIPTION
This prevent opening a local .gns3 on a remote server.
Because this is not working you need to import the
project on the server using portable project.

Fix https://github.com/GNS3/gns3-server/issues/984