### PR TITLE
Do not run import / export of project in seperate thread

### DIFF
--- a/gns3/topology.py
+++ b/gns3/topology.py
@@ -20,15 +20,12 @@ Contains this entire topology: nodes and links.
 """
 
 import os
-import json
 import xml.etree.ElementTree as ET
 
 
 from .local_server import LocalServer
-from .node import Node
 from .qt import QtCore, QtWidgets
 
-from .utils.process_files_worker import ProcessFilesWorker
 from .utils.progress_dialog import ProgressDialog
 from .utils.export_project_worker import ExportProjectWorker
 from .utils.import_project_worker import ImportProjectWorker
@@ -237,7 +234,7 @@ It is your responsability to check if you have the right to distribute the image
         self.editReadme()
 
         export_worker = ExportProjectWorker(self._project, path, include_images)
-        progress_dialog = ProgressDialog(export_worker, "Exporting project", "Exporting portable project files...", "Cancel", parent=self._main_window)
+        progress_dialog = ProgressDialog(export_worker, "Exporting project", "Exporting portable project files...", "Cancel", parent=self._main_window, create_thread=False)
         progress_dialog.show()
         progress_dialog.exec_()
 
@@ -252,7 +249,7 @@ It is your responsability to check if you have the right to distribute the image
                                             name=dialog.getProjectSettings()["project_name"],
                                             path=dialog.getProjectSettings().get("project_files_dir"))
         import_worker.imported.connect(self._projectImportedSlot)
-        progress_dialog = ProgressDialog(import_worker, "Importing project", "Importing portable project files...", "Cancel", parent=self._main_window)
+        progress_dialog = ProgressDialog(import_worker, "Importing project", "Importing portable project files...", "Cancel", parent=self._main_window, create_thread=False)
         progress_dialog.show()
         progress_dialog.exec_()
 

--- a/gns3/utils/export_project_worker.py
+++ b/gns3/utils/export_project_worker.py
@@ -15,12 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import zipfile
-import shutil
-
 from ..qt import QtCore
-from ..local_server import LocalServer
 
 
 class ExportProjectWorker(QtCore.QObject):
@@ -41,7 +36,6 @@ class ExportProjectWorker(QtCore.QObject):
 
     def run(self):
 
-        vm_server = None
         self._project.get("/export?include_images={}".format(self._include_images),
                           self._exportReceived,
                           downloadProgressCallback=self._downloadFileProgress,

--- a/gns3/utils/import_project_worker.py
+++ b/gns3/utils/import_project_worker.py
@@ -16,10 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pathlib
-import zipfile
 import uuid
-import os
-import sys
 
 
 from ..controller import Controller
@@ -69,4 +66,3 @@ class ImportProjectWorker(QtCore.QObject):
 
     def cancel(self):
         pass
-

--- a/gns3/utils/progress_dialog.py
+++ b/gns3/utils/progress_dialog.py
@@ -167,8 +167,6 @@ class ProgressDialog(QtWidgets.QProgressDialog):
         :param message: message
         """
 
-        if not self._thread:
-            return
         if stop:
             log.critical("{} thread stopping with an error: {}".format(self._worker.objectName(), message))
             QtWidgets.QMessageBox.critical(self.parentWidget(), "Error", "{}".format(message))


### PR DESCRIPTION
This trigger warning because you need to do the HTTP request
to the API from the main thread.

I also dropped some unused code in the import and export class.

Fix #2008 