### PR TITLE
Fix lost slot and port in dynamips settings

### DIFF
--- a/gns3/modules/dynamips/nodes/router.py
+++ b/gns3/modules/dynamips/nodes/router.py
@@ -24,9 +24,7 @@ import re
 
 from gns3.node import Node
 from gns3.utils.normalize_filename import normalize_filename
-from gns3.image_manager import ImageManager
 
-from ..settings import PLATFORMS_DEFAULT_RAM
 from ..adapters import ADAPTER_MATRIX
 from ..wics import WIC_MATRIX
 

--- a/gns3/node.py
+++ b/gns3/node.py
@@ -338,9 +338,7 @@ class Node(BaseNode):
 
         if "properties" in result:
             for name, value in result["properties"].items():
-                if name.startswith("slot") or name.startswith("wic"):
-                    pass
-                elif name in self._settings and self._settings[name] != value:
+                if name in self._settings and self._settings[name] != value:
                     log.debug("{} setting up and updating {} from '{}' to '{}'".format(self.name(), name, self._settings[name], value))
                     self._settings[name] = value
 


### PR DESCRIPTION
When you reopen a project you no longer have the
wic and slot, until you move the node and retrieve an
update. The settings is just lost in the GUI but is fine
on server.

Fix #2053