### PR TITLE
Filter additional QXcbConnection log messages

### DIFF
--- a/gns3/qt/__init__.py
+++ b/gns3/qt/__init__.py
@@ -293,6 +293,8 @@ def myQtMsgHandler(msg_type, msg_log_context, msg_string):
     if "_COMPIZ_TOOLKIT_ACTION" in msg_string:
         # Qt < 5.6 issue: https://github.com/GNS3/gns3-gui/issues/2020
         return
+    if msg_string.startswith("QXcbConnection"):  # Qt noise not relevant
+        return
     log.info(msg_string)
 
 


### PR DESCRIPTION
QXcbConnection log messages still pop up from time to time (even after 116cf5), filter them here as well.