### PR TITLE
Disable direct file upload on default

### DIFF
--- a/gns3/settings.py
+++ b/gns3/settings.py
@@ -270,7 +270,7 @@ GENERAL_SETTINGS = {
     "debug_level": 0,
     "multi_profiles": False,
     "hdpi": not sys.platform.startswith("linux"),
-    "direct_file_upload": True
+    "direct_file_upload": False
 }
 
 NODES_VIEW_SETTINGS = {


### PR DESCRIPTION
We have solution why uploads are slow on Windows, however after disabling debug mode makes that aiohttp screams:

`Exception in callback _ProactorReadPipeTransport._loop_reading(<_OverlappedF...\xc3\x8e\xa3'>)
handle: <Handle _ProactorReadPipeTransport._loop_reading(<_OverlappedF...\xc3\x8e\xa3'>)>
Traceback (most recent call last):
  File "C:\Python36\lib\asyncio\events.py", line 127, in _run
    self._callback(*self._args)
  File "C:\Python36\lib\asyncio\proactor_events.py", line 188, in _loop_reading
    self._closing)
AssertionError
b''`

Because of that, please don't merge it now. 