### PR TITLE
Custom persistent docker volumes

### DIFF
--- a/gns3/modules/docker/docker_vm.py
+++ b/gns3/modules/docker/docker_vm.py
@@ -51,7 +51,8 @@ class DockerVM(Node):
                               "console_resolution": DOCKER_CONTAINER_SETTINGS["console_resolution"],
                               "console_http_port": DOCKER_CONTAINER_SETTINGS["console_http_port"],
                               "console_http_path": DOCKER_CONTAINER_SETTINGS["console_http_path"],
-                              "extra_hosts": DOCKER_CONTAINER_SETTINGS["extra_hosts"]}
+                              "extra_hosts": DOCKER_CONTAINER_SETTINGS["extra_hosts"],
+                              "extra_volumes": DOCKER_CONTAINER_SETTINGS["extra_volumes"]}
 
         self.settings().update(docker_vm_settings)
 

--- a/gns3/modules/docker/pages/docker_vm_configuration_page.py
+++ b/gns3/modules/docker/pages/docker_vm_configuration_page.py
@@ -104,6 +104,7 @@ class DockerVMConfigurationPage(QtWidgets.QWidget, Ui_dockerVMConfigPageWidget):
         self.uiConsoleHttpPortSpinBox.setValue(settings["console_http_port"])
         self.uiHttpConsolePathLineEdit.setText(settings["console_http_path"])
         self.uiExtraHostsTextEdit.setText(settings["extra_hosts"])
+        self.uiExtraVolumeTextEdit.setPlainText("\n".join(settings["extra_volumes"]))
 
         if not group:
             self.uiNameLineEdit.setText(settings["name"])
@@ -175,6 +176,8 @@ class DockerVMConfigurationPage(QtWidgets.QWidget, Ui_dockerVMConfigPageWidget):
         settings["console_http_port"] = self.uiConsoleHttpPortSpinBox.value()
         settings["console_http_path"] = self.uiHttpConsolePathLineEdit.text()
         settings["extra_hosts"] = self.uiExtraHostsTextEdit.toPlainText()
+        # only tidy input here, validation is performed server side
+        settings["extra_volumes"] = [ y for x in self.uiExtraVolumeTextEdit.toPlainText().split("\n") for y in [ x.strip() ] if y ]
 
         if not group:
             adapters = self.uiAdapterSpinBox.value()

--- a/gns3/modules/docker/pages/docker_vm_configuration_page.py
+++ b/gns3/modules/docker/pages/docker_vm_configuration_page.py
@@ -103,7 +103,7 @@ class DockerVMConfigurationPage(QtWidgets.QWidget, Ui_dockerVMConfigPageWidget):
         self.uiConsoleResolutionComboBox.setCurrentIndex(self.uiConsoleResolutionComboBox.findText(settings["console_resolution"]))
         self.uiConsoleHttpPortSpinBox.setValue(settings["console_http_port"])
         self.uiHttpConsolePathLineEdit.setText(settings["console_http_path"])
-        self.uiExtraHostsTextEdit.setText(settings["extra_hosts"])
+        self.uiExtraHostsTextEdit.setPlainText(settings["extra_hosts"])
         self.uiExtraVolumeTextEdit.setPlainText("\n".join(settings["extra_volumes"]))
 
         if not group:

--- a/gns3/modules/docker/pages/docker_vm_preferences_page.py
+++ b/gns3/modules/docker/pages/docker_vm_preferences_page.py
@@ -95,6 +95,9 @@ class DockerVMPreferencesPage(QtWidgets.QWidget, Ui_DockerVMPreferencesPageWidge
         if docker_container["extra_hosts"]:
             QtWidgets.QTreeWidgetItem(section_item, ["Extra hosts:", str(docker_container["extra_hosts"])])
 
+        if docker_image["extra_volumes"]:
+            QtWidgets.QTreeWidgetItem(section_item, ["Extra volumes:", "\n".join(docker_image["extra_volumes"])])
+
         self.uiDockerVMInfoTreeWidget.expandAll()
         self.uiDockerVMInfoTreeWidget.resizeColumnToContents(0)
         self.uiDockerVMInfoTreeWidget.resizeColumnToContents(1)

--- a/gns3/modules/docker/settings.py
+++ b/gns3/modules/docker/settings.py
@@ -43,5 +43,6 @@ DOCKER_CONTAINER_SETTINGS = {
     "console_http_port": 80,
     "console_http_path": "/",
     "extra_hosts": "",
+    "extra_volumes": [],
     "node_type": "docker"
 }

--- a/gns3/modules/docker/ui/docker_vm_configuration_page.ui
+++ b/gns3/modules/docker/ui/docker_vm_configuration_page.ui
@@ -299,7 +299,28 @@ one per line)</string>
        <item row="0" column="1">
         <widget class="QTextEdit" name="uiExtraHostsTextEdit"/>
        </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="uiExtraVolumeLabel">
+         <property name="text">
+          <string>Additional directories to
+make persistent that are
+not included in the image
+VOLUMES config. One
+directory per line.</string>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="1">
+        <widget class="QPlainTextEdit" name="uiExtraVolumeTextEdit">
+         <property name="plainText">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>e.g. /etc/sysctl.d</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/gns3/modules/docker/ui/docker_vm_configuration_page.ui
+++ b/gns3/modules/docker/ui/docker_vm_configuration_page.ui
@@ -297,7 +297,11 @@ one per line)</string>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QTextEdit" name="uiExtraHostsTextEdit"/>
+        <widget class="QPlainTextEdit" name="uiExtraHostsTextEdit">
+         <property name="placeholderText">
+          <string>e.g. router:192.168.0.1</string>
+         </property>
+        </widget>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="uiExtraVolumeLabel">

--- a/gns3/modules/docker/ui/docker_vm_configuration_page_ui.py
+++ b/gns3/modules/docker/ui/docker_vm_configuration_page_ui.py
@@ -146,8 +146,15 @@ class Ui_dockerVMConfigPageWidget(object):
         self.uiExtraHostsTextEdit = QtWidgets.QTextEdit(self.tab_2)
         self.uiExtraHostsTextEdit.setObjectName("uiExtraHostsTextEdit")
         self.gridLayout_2.addWidget(self.uiExtraHostsTextEdit, 0, 1, 1, 1)
+        self.uiExtraVolumeLabel = QtWidgets.QLabel(self.tab_2)
+        self.uiExtraVolumeLabel.setObjectName("uiExtraVolumeLabel")
+        self.gridLayout_2.addWidget(self.uiExtraVolumeLabel, 1, 0, 1, 1)
+        self.uiExtraVolumeTextEdit = QtWidgets.QPlainTextEdit(self.tab_2)
+        self.uiExtraVolumeTextEdit.setPlainText("")
+        self.uiExtraVolumeTextEdit.setObjectName("uiExtraVolumeTextEdit")
+        self.gridLayout_2.addWidget(self.uiExtraVolumeTextEdit, 1, 1, 1, 1)
         spacerItem = QtWidgets.QSpacerItem(20, 388, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout_2.addItem(spacerItem, 1, 1, 1, 1)
+        self.gridLayout_2.addItem(spacerItem, 2, 1, 1, 1)
         self.uiTabWidget.addTab(self.tab_2, "")
         self.tab_3 = QtWidgets.QWidget()
         self.tab_3.setObjectName("tab_3")
@@ -201,6 +208,12 @@ class Ui_dockerVMConfigPageWidget(object):
 "to the /etc/hosts file.\n"
 "(hostname:IP\n"
 "one per line)"))
+        self.uiExtraVolumeLabel.setText(_translate("dockerVMConfigPageWidget", "Additional directories to\n"
+"make persistent that are\n"
+"not included in the image\n"
+"VOLUMES config. One\n"
+"directory per line."))
+        self.uiExtraVolumeTextEdit.setPlaceholderText(_translate("dockerVMConfigPageWidget", "e.g. /etc/sysctl.d"))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab_2), _translate("dockerVMConfigPageWidget", "Advanced"))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab_3), _translate("dockerVMConfigPageWidget", "Usage"))
 

--- a/gns3/modules/docker/ui/docker_vm_configuration_page_ui.py
+++ b/gns3/modules/docker/ui/docker_vm_configuration_page_ui.py
@@ -143,7 +143,7 @@ class Ui_dockerVMConfigPageWidget(object):
         self.uiExtraHostsLabel.setWordWrap(True)
         self.uiExtraHostsLabel.setObjectName("uiExtraHostsLabel")
         self.gridLayout_2.addWidget(self.uiExtraHostsLabel, 0, 0, 1, 1)
-        self.uiExtraHostsTextEdit = QtWidgets.QTextEdit(self.tab_2)
+        self.uiExtraHostsTextEdit = QtWidgets.QPlainTextEdit(self.tab_2)
         self.uiExtraHostsTextEdit.setObjectName("uiExtraHostsTextEdit")
         self.gridLayout_2.addWidget(self.uiExtraHostsTextEdit, 0, 1, 1, 1)
         self.uiExtraVolumeLabel = QtWidgets.QLabel(self.tab_2)
@@ -208,6 +208,7 @@ class Ui_dockerVMConfigPageWidget(object):
 "to the /etc/hosts file.\n"
 "(hostname:IP\n"
 "one per line)"))
+        self.uiExtraHostsTextEdit.setPlaceholderText(_translate("dockerVMConfigPageWidget", "e.g. router:192.168.0.1"))
         self.uiExtraVolumeLabel.setText(_translate("dockerVMConfigPageWidget", "Additional directories to\n"
 "make persistent that are\n"
 "not included in the image\n"

--- a/gns3/schemas/appliance.json
+++ b/gns3/schemas/appliance.json
@@ -166,6 +166,13 @@
             "extra_hosts": {
                 "description": "Hosts which will be written to /etc/hosts into container" ,
                 "type": "string"
+            },
+            "extra_volumes": {
+                "description": "Additional directories to make persistent that are not included in the images VOLUME directive" ,
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
             }
         },
         "required": [


### PR DESCRIPTION
Corresponds to pull request in gns3-server: https://github.com/GNS3/gns3-server/pull/1584

Provides the UI changes to configure the persistent volumes. There is also an additional patch to style the extra_hosts text edit in the same way as the extra_volumes one.