### PR TITLE
Hide config import/export when configFiles attribute is empty

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -861,19 +861,19 @@ class GraphicsView(QtWidgets.QGraphicsView):
             bring_to_front_action.triggered.connect(self.bringToFrontSlot)
             menu.addAction(bring_to_front_action)
 
-        if True in list(map(lambda item: isinstance(item, NodeItem) and hasattr(item.node(), "configFiles"), items)):
+        if True in list(map(lambda item: isinstance(item, NodeItem) and bool(item.node().configFiles()), items)):
             import_config_action = QtWidgets.QAction("Import config", menu)
             import_config_action.setIcon(get_icon("import.svg"))
             import_config_action.triggered.connect(self.importConfigActionSlot)
             menu.addAction(import_config_action)
 
-        if True in list(map(lambda item: isinstance(item, NodeItem) and hasattr(item.node(), "configFiles"), items)):
+        if True in list(map(lambda item: isinstance(item, NodeItem) and bool(item.node().configFiles()), items)):
             export_config_action = QtWidgets.QAction("Export config", menu)
             export_config_action.setIcon(get_icon("export.svg"))
             export_config_action.triggered.connect(self.exportConfigActionSlot)
             menu.addAction(export_config_action)
 
-        if True in list(map(lambda item: isinstance(item, NodeItem) and hasattr(item.node(), "configFiles"), items)):
+        if True in list(map(lambda item: isinstance(item, NodeItem) and bool(item.node().configFiles()), items)):
             export_config_action = QtWidgets.QAction("Edit config", menu)
             export_config_action.setIcon(get_icon("edit.svg"))
             export_config_action.triggered.connect(self.editConfigActionSlot)
@@ -1226,7 +1226,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
         items = []
         for item in self.scene().selectedItems():
-            if isinstance(item, NodeItem) and hasattr(item.node(), "configFiles") and item.node().initialized():
+            if isinstance(item, NodeItem) and item.node().configFiles() and item.node().initialized():
                 items.append(item)
 
         if not items:
@@ -1257,7 +1257,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
         items = []
         for item in self.scene().selectedItems():
-            if isinstance(item, NodeItem) and hasattr(item.node(), "configFiles") and item.node().initialized():
+            if isinstance(item, NodeItem) and item.node().configFiles() and item.node().initialized():
                 items.append(item)
 
         if not items:
@@ -1282,7 +1282,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
         items = []
         for item in self.scene().selectedItems():
-            if isinstance(item, NodeItem) and hasattr(item.node(), "configFiles") and item.node().initialized():
+            if isinstance(item, NodeItem) and item.node().configFiles() and item.node().initialized():
                 items.append(item)
 
         if not items:

--- a/gns3/modules/qemu/qemu_vm.py
+++ b/gns3/modules/qemu/qemu_vm.py
@@ -144,7 +144,9 @@ class QemuVM(Node):
         Name of the configuration files
         """
 
-        return ["config.zip"]
+        if self._settings.get("create_config_disk"):
+            return ["config.zip"]
+        return None
 
     def auxConsole(self):
         """

--- a/gns3/node.py
+++ b/gns3/node.py
@@ -199,6 +199,17 @@ class Node(BaseNode):
 
         return self._always_on
 
+    def configFiles(self):
+        """
+        Name of the configuration files
+
+        This method should be overridden in derived classes
+
+        :returns: List of configuration files, False if no files
+        """
+
+        return None
+
     def get(self, path, *args, **kwargs):
         """
         GET on current server / project
@@ -786,7 +797,7 @@ class Node(BaseNode):
         :param directory: destination directory path
         """
 
-        if not hasattr(self, "configFiles"):
+        if not self.configFiles():
             return False
         for file in self.configFiles():
             self.get("/files/{file}".format(file=file),
@@ -825,7 +836,7 @@ class Node(BaseNode):
         :param directory: source directory path
         """
 
-        if not hasattr(self, "configFiles"):
+        if not self.configFiles():
             return
 
         try:


### PR DESCRIPTION
Implements idea from https://github.com/GNS3/gns3-server/pull/1801:

> * show the import/export/edit config option only, when the config option is selected for that VM
>   That is tricky as currently `hasattr(instance, "exportConfigs")` is used to test if a config is available. My idea is to always have the exportConfigs method, but test if it returns an non-empty list. But as this is used in a lot of places this will be a large change.

This PR creates a dummy exportConfigs method in the node class, so `hasattr(instance, "exportConfigs")` is always true for node items and doesn't need to be checked. The check, if a config file is available, is now done by testing if exportConfigs() returns a non-empty list of files. A boolean False value (False / None / empty list) means, that no config file is available.

For QEMU nodes the list of config file now gets populated only, when the node attribute create_config_disk is set.