### PR TITLE
Edit only text mode config files

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -873,7 +873,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
             export_config_action.triggered.connect(self.exportConfigActionSlot)
             menu.addAction(export_config_action)
 
-        if True in list(map(lambda item: isinstance(item, NodeItem) and bool(item.node().configFiles()), items)):
+        if True in list(map(lambda item: isinstance(item, NodeItem) and bool(item.node().configTextFiles()), items)):
             export_config_action = QtWidgets.QAction("Edit config", menu)
             export_config_action.setIcon(get_icon("edit.svg"))
             export_config_action.triggered.connect(self.editConfigActionSlot)
@@ -1257,17 +1257,17 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
         items = []
         for item in self.scene().selectedItems():
-            if isinstance(item, NodeItem) and item.node().configFiles() and item.node().initialized():
+            if isinstance(item, NodeItem) and item.node().configTextFiles() and item.node().initialized():
                 items.append(item)
 
         if not items:
             return
 
         for item in items:
-            if len(item.node().configFiles()) == 1:
-                config_file = item.node().configFiles()[0]
+            if len(item.node().configTextFiles()) == 1:
+                config_file = item.node().configTextFiles()[0]
             else:
-                config_file, ok = QtWidgets.QInputDialog.getItem(self, "Edit file", "File to edit?", item.node().configFiles(), 0, False)
+                config_file, ok = QtWidgets.QInputDialog.getItem(self, "Edit file", "File to edit?", item.node().configTextFiles(), 0, False)
                 if not ok:
                     continue
             dialog = FileEditorDialog(item.node(), config_file, parent=self)

--- a/gns3/modules/qemu/qemu_vm.py
+++ b/gns3/modules/qemu/qemu_vm.py
@@ -148,6 +148,15 @@ class QemuVM(Node):
             return ["config.zip"]
         return None
 
+    def configTextFiles(self):
+        """
+        Name of the configuration files, which are plain text files
+
+        :returns: List of configuration files, False if no files
+        """
+
+        return None
+
     def auxConsole(self):
         """
         Returns the console port for this Docker VM instance.

--- a/gns3/node.py
+++ b/gns3/node.py
@@ -210,6 +210,15 @@ class Node(BaseNode):
 
         return None
 
+    def configTextFiles(self):
+        """
+        Name of the configuration files, which are plain text files
+
+        :returns: List of configuration files, False if no files
+        """
+
+        return self.configFiles()
+
     def get(self, path, *args, **kwargs):
         """
         GET on current server / project


### PR DESCRIPTION
Implements idea from GNS3/gns3-server#1801:

>  * the edit config makes no sense for binary config data like the zip file. But I have no good idea how to limit the edit function to text configurations.

Added the method `configTextFiles`, which returns only config files, that are pure text files. By default, that method returns the list of config files. But this method can be overridden to return only a subset of config files. In case of QEMU VMs, it resturns no fiiles.