### PR TITLE
Make remote server capture reliable (Workaround, requires curl)

### DIFF
--- a/gns3/link.py
+++ b/gns3/link.py
@@ -119,12 +119,6 @@ class Link(QtCore.QObject):
                 else:
                     self._capture_file = QtCore.QFile(self._capture_file_path)
                     self._capture_file.open(QtCore.QFile.WriteOnly)
-                Controller.instance().get("/projects/{project_id}/links/{link_id}/pcap".format(project_id=self.project().id(), link_id=self._link_id),
-                                          None,
-                                          showProgress=False,
-                                          downloadProgressCallback=self._downloadPcapProgress,
-                                          ignoreErrors=True,  # If something is wrong avoid disconnect us from server
-                                          timeout=None)
             log.debug("Capturing packets to '{}'".format(self._capture_file_path))
 
         if "nodes" in result:


### PR DESCRIPTION
As you can see in #3067, #2350, #2111, the "Packet Capture" feature is unstable and breaks after some time when using remote server as a main server.
For more details please read my issue #3067, there are a lot of details.
After debugging source code, I detected that the problem is somewhere in `http_client.py` called from `link.py:_parseResponse`
`Controller.instance().get` can silently fail in the background
I tried setting `ignoreErrors=False` and putting `eventsHandler` to `HTTPClient.createHTTPQuery` but didn't realized the interface it expects.

This PR resolves the problem by using `curl`, an external utility, which made responsible for continuous pcap file download from the gns3server. Windows users need `curl.exe` to be present in the distribution (`C:\Program Files\GNS3\curl.exe` for example)

This is not the best design, but it works and seems OK for me as a temporary solution. It would be fine to fix HTTPClient instead, but it's too difficult for me this time. I'm open for discussions and advices.