### PR TITLE
Docker enhancement to grant the user the ability to modify the contai…

### DIFF
--- a/gns3/modules/docker/docker_vm.py
+++ b/gns3/modules/docker/docker_vm.py
@@ -52,7 +52,8 @@ class DockerVM(Node):
                               "console_http_port": DOCKER_CONTAINER_SETTINGS["console_http_port"],
                               "console_http_path": DOCKER_CONTAINER_SETTINGS["console_http_path"],
                               "extra_hosts": DOCKER_CONTAINER_SETTINGS["extra_hosts"],
-                              "extra_volumes": DOCKER_CONTAINER_SETTINGS["extra_volumes"]}
+                              "extra_volumes": DOCKER_CONTAINER_SETTINGS["extra_volumes"],
+                              "extra_parameters": DOCKER_CONTAINER_SETTINGS["extra_parameters"]}
 
         self.settings().update(docker_vm_settings)
 

--- a/gns3/modules/docker/pages/docker_vm_configuration_page.py
+++ b/gns3/modules/docker/pages/docker_vm_configuration_page.py
@@ -105,6 +105,7 @@ class DockerVMConfigurationPage(QtWidgets.QWidget, Ui_dockerVMConfigPageWidget):
         self.uiHttpConsolePathLineEdit.setText(settings["console_http_path"])
         self.uiExtraHostsTextEdit.setPlainText(settings["extra_hosts"])
         self.uiExtraVolumeTextEdit.setPlainText("\n".join(settings["extra_volumes"]))
+        self.uiExtraParametersTextEdit.setPlainText(settings["extra_parameters"])
 
         if not group:
             self.uiNameLineEdit.setText(settings["name"])
@@ -178,6 +179,7 @@ class DockerVMConfigurationPage(QtWidgets.QWidget, Ui_dockerVMConfigPageWidget):
         settings["extra_hosts"] = self.uiExtraHostsTextEdit.toPlainText()
         # only tidy input here, validation is performed server side
         settings["extra_volumes"] = [ y for x in self.uiExtraVolumeTextEdit.toPlainText().split("\n") for y in [ x.strip() ] if y ]
+        settings["extra_parameters"] = self.uiExtraParametersTextEdit.toPlainText()
 
         if not group:
             adapters = self.uiAdapterSpinBox.value()

--- a/gns3/modules/docker/pages/docker_vm_preferences_page.py
+++ b/gns3/modules/docker/pages/docker_vm_preferences_page.py
@@ -97,6 +97,9 @@ class DockerVMPreferencesPage(QtWidgets.QWidget, Ui_DockerVMPreferencesPageWidge
 
         if docker_container["extra_volumes"]:
             QtWidgets.QTreeWidgetItem(section_item, ["Extra volumes:", "\n".join(docker_container["extra_volumes"])])
+        
+        if docker_container["extra_parameters"]:
+            QtWidgets.QTreeWidgetItem(section_item, ["Extra parameters:", str(docker_container["extra_parameters"])])
 
         self.uiDockerVMInfoTreeWidget.expandAll()
         self.uiDockerVMInfoTreeWidget.resizeColumnToContents(0)

--- a/gns3/modules/docker/settings.py
+++ b/gns3/modules/docker/settings.py
@@ -44,5 +44,6 @@ DOCKER_CONTAINER_SETTINGS = {
     "console_http_path": "/",
     "extra_hosts": "",
     "extra_volumes": [],
+    "extra_parameters": "",
     "node_type": "docker"
 }

--- a/gns3/modules/docker/ui/docker_vm_configuration_page.ui
+++ b/gns3/modules/docker/ui/docker_vm_configuration_page.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="uiTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -324,18 +324,53 @@ directory per line.</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
+       <item row="2" column="0">
+        <widget class="QLabel" name="uiExtraParametersLabel">
+         <property name="minimumSize">
           <size>
-           <width>20</width>
+           <width>10</width>
            <height>388</height>
           </size>
          </property>
-        </spacer>
+         <property name="text">
+          <string>Modify parameters to
+create the container
+using the JSON format of
+the Docker API, use only
+if you have a specific
+requirement e.g. systemd.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QPlainTextEdit" name="uiExtraParametersTextEdit">
+         <property name="plainText">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>e.g. systemd
+{
+    &quot;StopSignal&quot;: &quot;SIGRTMIN+3&quot;,
+    &quot;HostConfig&quot;: {
+        &quot;CapAdd&quot;: [&quot;ALL&quot;],
+        &quot;Runtime&quot;: &quot;runc&quot;,
+        &quot;Privileged&quot;: true,
+        &quot;Binds&quot;: [
+            &quot;/sys/fs/cgroup:/sys/fs/cgroup:ro&quot;,
+            &quot;/sys/fs/fuse:/sys/fs/fuse&quot;
+        ],
+        &quot;Tmpfs&quot;: {
+            &quot;/tmp&quot;: &quot;&quot;,
+            &quot;/run&quot;: &quot;&quot;,
+            &quot;/run/lock&quot;: &quot;&quot;
+        }
+    }
+}</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/gns3/modules/docker/ui/docker_vm_configuration_page_ui.py
+++ b/gns3/modules/docker/ui/docker_vm_configuration_page_ui.py
@@ -153,8 +153,16 @@ class Ui_dockerVMConfigPageWidget(object):
         self.uiExtraVolumeTextEdit.setPlainText("")
         self.uiExtraVolumeTextEdit.setObjectName("uiExtraVolumeTextEdit")
         self.gridLayout_2.addWidget(self.uiExtraVolumeTextEdit, 1, 1, 1, 1)
-        spacerItem = QtWidgets.QSpacerItem(20, 388, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.gridLayout_2.addItem(spacerItem, 2, 1, 1, 1)
+      
+        self.uiExtraParametersLabel = QtWidgets.QLabel(self.tab_2)
+        self.uiExtraParametersLabel.setObjectName("uiExtraParametersLabel")
+        self.uiExtraParametersLabel.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignLeading | QtCore.Qt.AlignTop)
+        self.gridLayout_2.addWidget(self.uiExtraParametersLabel, 2, 0, 1, 1)
+        
+        self.uiExtraParametersTextEdit = QtWidgets.QPlainTextEdit(self.tab_2)
+        self.uiExtraParametersTextEdit.setPlainText("")
+        self.uiExtraParametersTextEdit.setObjectName("uiExtraParametersTextEdit")
+        self.gridLayout_2.addWidget(self.uiExtraParametersTextEdit, 2, 1, 1, 1)
         self.uiTabWidget.addTab(self.tab_2, "")
         self.tab_3 = QtWidgets.QWidget()
         self.tab_3.setObjectName("tab_3")
@@ -215,6 +223,30 @@ class Ui_dockerVMConfigPageWidget(object):
 "VOLUMES config. One\n"
 "directory per line."))
         self.uiExtraVolumeTextEdit.setPlaceholderText(_translate("dockerVMConfigPageWidget", "e.g. /etc/sysctl.d"))
+        self.uiExtraParametersLabel.setText(_translate("dockerVMConfigPageWidget", "Modify parameters to\n"
+"create the container\n"
+"using the JSON format of\n"
+"the Docker API, use only\n"
+"if you have a specific\n"
+"requirement"))
+        self.uiExtraParametersTextEdit.setPlaceholderText(_translate("dockerVMConfigPageWidget", """e.g. systemd
+{
+    "StopSignal": "SIGRTMIN+3",
+    "HostConfig": {
+        "CapAdd": ["ALL"],
+        "Runtime": "runc",
+        "Privileged": true,
+        "Binds": [
+            "/sys/fs/cgroup:/sys/fs/cgroup:ro",
+            "/sys/fs/fuse:/sys/fs/fuse"
+        ],
+        "Tmpfs": {
+            "/tmp": "",
+            "/run": "",
+            "/run/lock": ""
+        }
+    }
+}"""))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab_2), _translate("dockerVMConfigPageWidget", "Advanced"))
         self.uiTabWidget.setTabText(self.uiTabWidget.indexOf(self.tab_3), _translate("dockerVMConfigPageWidget", "Usage"))
 


### PR DESCRIPTION
Docker - Add custom parameters to the container create

Why:

Several use cases require the need to alter the docker container create
  1. Running systemd containers require special binds plus a custom termination signal
  2. Running systemd in sysbox containers require custom runtime as well as Privileged=false
  3. Many other use cases exist and will only grow as Docker becomes even more commonplace

This change addresses the need by:

 1. Adding a custom textedit to the Docker container Advanced tab
 2. Adding the custom fields to the GNS3 schemas and objects
 3. Adding logic to the Docker create function to merge the custom parameters

NB: This change is depenant on modifications to both gns3-gui and gns3-server