### PR TITLE
gns3server losts its compute_id in scalable environnement

### DIFF
--- a/gns3/controller.py
+++ b/gns3/controller.py
@@ -130,9 +130,8 @@ class Controller(QtCore.QObject):
 
         self._connected = False
         self._connecting = True
-
-        # Immediately connect to the server
-        QtCore.QTimer.singleShot(0, qpartial(self.get, '/version', self._versionGetSlot, showProgress=self._first_error))
+        status, json_data = self.httpClient().getSynchronous('GET', '/version', timeout=60)
+        self._versionGetSlot(json_data, status >= 300)
 
     def _httpClientDisconnectedSlot(self):
         if self._connected:

--- a/gns3/controller.py
+++ b/gns3/controller.py
@@ -131,7 +131,7 @@ class Controller(QtCore.QObject):
         self._connected = False
         self._connecting = True
         status, json_data = self.httpClient().getSynchronous('GET', '/version', timeout=60)
-        self._versionGetSlot(json_data, status >= 300)
+        self._versionGetSlot(json_data, status is None or status >= 300)
 
     def _httpClientDisconnectedSlot(self):
         if self._connected:
@@ -149,11 +149,14 @@ class Controller(QtCore.QObject):
             if self._first_error:
                 self._connecting = False
                 self.connection_failed_signal.emit()
-                if "message" in result and self._display_error:
+                if self._display_error:
                     self._error_dialog = QtWidgets.QMessageBox(self.parent())
                     self._error_dialog.setWindowModality(QtCore.Qt.ApplicationModal)
                     self._error_dialog.setWindowTitle("Connection to server")
-                    self._error_dialog.setText("Error when connecting to the GNS3 server:\n{}".format(result["message"]))
+                    if result and "message" in result:
+                        self._error_dialog.setText("Error when connecting to the GNS3 server:\n{}".format(result["message"]))
+                    else:
+                        self._error_dialog.setText("Cannot connect to the GNS3 server")
                     self._error_dialog.setIcon(QtWidgets.QMessageBox.Critical)
                     self._error_dialog.show()
             # Try to connect again in 5 seconds

--- a/gns3/controller.py
+++ b/gns3/controller.py
@@ -130,7 +130,9 @@ class Controller(QtCore.QObject):
 
         self._connected = False
         self._connecting = True
-        self.httpClient().getSynchronous('/version', self._versionGetSlot, timeout=60)
+
+        # Immediately connect to the server
+        QtCore.QTimer.singleShot(0, qpartial(self.get, '/version', self._versionGetSlot, showProgress=self._first_error))
 
     def _httpClientDisconnectedSlot(self):
         if self._connected:

--- a/gns3/controller.py
+++ b/gns3/controller.py
@@ -168,6 +168,7 @@ class Controller(QtCore.QObject):
                 self._error_dialog.reject()
                 self._error_dialog = None
             self._version = result.get("version")
+            self._http_client.connection_connected_signal.emit()
 
     def _httpClientConnectedSlot(self):
 

--- a/gns3/topology.py
+++ b/gns3/topology.py
@@ -62,7 +62,7 @@ class Topology(QtCore.QObject):
         self._main_window = None
 
         # If set the project is loaded when we got connection to the controller
-        # usefull when we open a project from cli or when server restart
+        # useful when we open a project from cli or when server restart
         self._project_to_load_path = None
         self._project_id_to_load = None
 

--- a/gns3/version.py
+++ b/gns3/version.py
@@ -23,7 +23,7 @@
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
 
-__version__ = "2.2.20dev1"
+__version__ = "2.2.20dev2"
 __version_info__ = (2, 2, 20, 99)
 
 if "dev" in __version__:

--- a/gns3/version.py
+++ b/gns3/version.py
@@ -23,8 +23,8 @@
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
 
-__version__ = "2.2.19"
-__version_info__ = (2, 2, 19, 0)
+__version__ = "2.2.20dev1"
+__version_info__ = (2, 2, 20, 99)
 
 if "dev" in __version__:
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema==3.2.0
-sentry-sdk>=0.14.4
-psutil==5.6.7
-distro>=1.3.0
+sentry-sdk==1.0.0
+psutil==5.8.0
+distro==1.5.0

--- a/win-requirements.txt
+++ b/win-requirements.txt
@@ -1,4 +1,4 @@
 -rrequirements.txt
 
-PyQt5==5.12.3 # pyup: ignore
-pywin32>=223 # pyup: ignore
+PyQt5==5.15.4 # pyup: ignore
+pywin32==300 # pyup: ignore

--- a/win-requirements.txt
+++ b/win-requirements.txt
@@ -1,4 +1,4 @@
 -rrequirements.txt
 
-PyQt5==5.15.4 # pyup: ignore
+PyQt5==5.15.2 # pyup: ignore
 pywin32==300 # pyup: ignore

--- a/win-requirements.txt
+++ b/win-requirements.txt
@@ -1,4 +1,4 @@
 -rrequirements.txt
 
-PyQt5==5.15.2 # pyup: ignore
+PyQt5==5.12.3 # pyup: ignore
 pywin32==300 # pyup: ignore


### PR DESCRIPTION
When you run multiple gns3 servers to have project in scalable mode, one is the controller.
Project data & files is spread on all servers depending where the appliance should run, and the project.gns3 file indicates where node should run (compute_id).
But when restarting gns3server elsewhere than the controler node, the compute_id of the gns3server changes.

From this, project cant run because controler cant find the old compute_id anymore.

Solution : enforce into the gns3_controller.conf file the compute_id of ALL gns3servers, whether it is a controller by another controller or not.