### PR TITLE
Fixed drawLine called with float arguments

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -1663,11 +1663,11 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
                 x = left
                 while x < rect.right():
-                    painter.drawLine(x, rect.top(), x, rect.bottom())
+                    painter.drawLine(x, int(rect.top()), x, int(rect.bottom()))
                     x += grid
                 y = top
                 while y < rect.bottom():
-                    painter.drawLine(rect.left(), y, rect.right(), y)
+                    painter.drawLine(int(rect.left()), y, int(rect.right()), y)
                     y += grid
             painter.restore()
 


### PR DESCRIPTION
Fixed a rare case (that happened to me) where drawLine was called with float arguments (rect.top(), rect.bottom(), rect.left(), rect.right()) preventing from drawing the background grid 