### PR TITLE
Fix create_link test

### DIFF
--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -104,9 +104,6 @@ def test_create_link(devices, project, controller):
     assert link._link_id is not None
     assert not devices[0].ports()[0].isFree()
 
-    assert link in devices[0].links()
-    assert link in devices[1].links()
-
     assert link.getNodePort(devices[0]) == devices[0].ports()[0]
     assert link.getNodePort(devices[1]) == devices[1].ports()[0]
 


### PR DESCRIPTION
The create_link test is failing with the following error.  This started after this change: https://github.com/GNS3/gns3-gui/commit/545a9f53#diff-c82fb679ee95de7e79fd605f3c46960711ca921079b55a6f665869a3b19d2aafL94-L95

I think the change in this PR will resolve the issue.  I believe the lines in the test were missed when creating the above change.

```
_______________________________ test_create_link _______________________________

devices = (<gns3.modules.vpcs.vpcs_node.VPCSNode object at 0x7f376d193d00>, <gns3.modules.vpcs.vpcs_node.VPCSNode object at 0x7f376d193eb0>)
project = <gns3.project.Project object at 0x7f376d192e60>
controller = <MagicMock id='139876008795088'>

    def test_create_link(devices, project, controller):
        link = Link(devices[0], devices[0].ports()[0], devices[1], devices[1].ports()[0])
    
        data = {
            "suspend": False,
            "nodes": [
                {"node_id": devices[0].node_id(), "adapter_number": 0, "port_number": 0},
                {"node_id": devices[1].node_id(), "adapter_number": 0, "port_number": 0},
            ],
            "link_style": {},
            "filters": {},
        }
    
        controller.post.assert_called_with("/projects/{}/links".format(project.id()), link._linkCreatedCallback, body=data)
    
        mock_signal = MagicMock()
        link.add_link_signal.connect(mock_signal)
        link._linkCreatedCallback({"link_id": str(uuid.uuid4())})
        mock_signal.assert_called_with(link._id)
    
        assert link._link_id is not None
        assert not devices[0].ports()[0].isFree()
    
>       assert link in devices[0].links()
E       assert <gns3.link.Link object at 0x7f376d193130> in set()
E        +  where set() = <bound method BaseNode.links of <gns3.modules.vpcs.vpcs_node.VPCSNode object at 0x7f376d193d00>>()
E        +    where <bound method BaseNode.links of <gns3.modules.vpcs.vpcs_node.VPCSNode object at 0x7f376d193d00>> = <gns3.modules.vpcs.vpcs_node.VPCSNode object at 0x7f376d193d00>.links

tests/test_link.py:107: AssertionError
```
