### PR TITLE
Fixed QPoint called with floats

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -723,8 +723,8 @@ class GraphicsView(QtWidgets.QGraphicsView):
                 integer, ok = QtWidgets.QInputDialog.getInt(self, "Nodes", "Number of nodes:", 2, 1, 100, 1)
                 if ok:
                     for node_number in range(integer):
-                        x = int(event.pos().x() - (150 / 2) + (node_number % max_nodes_per_line) * offset)
-                        y = int(event.pos().y() - (70 / 2) + (node_number // max_nodes_per_line) * offset)
+                        x = event.pos().x() - (150 // 2) + (node_number % max_nodes_per_line) * offset
+                        y = event.pos().y() - (70 // 2) + (node_number // max_nodes_per_line) * offset
                         if self.createNodeFromTemplateId(template_id, QtCore.QPoint(x, y)) is False:
                             event.ignore()
                             break

--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -473,7 +473,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
             #QtWidgets.QApplication.sendEvent(self, context_event)
         elif event.button() == QtCore.Qt.LeftButton and self._adding_note:
             pos = self.mapToScene(event.pos())
-            note = self.createDrawingItem("text", pos.x(), pos.y(), 2)
+            note = self.createDrawingItem("text", int(pos.x()), int(pos.y()), 2)
             pos_x = note.pos().x()
             pos_y = note.pos().y() - (note.boundingRect().height() / 2)
             note.setPos(pos_x, pos_y)
@@ -483,19 +483,19 @@ class GraphicsView(QtWidgets.QGraphicsView):
             self._adding_note = False
         elif event.button() == QtCore.Qt.LeftButton and self._adding_rectangle:
             pos = self.mapToScene(event.pos())
-            self.createDrawingItem("rect", pos.x(), pos.y(), 1)
+            self.createDrawingItem("rect", int(pos.x()), int(pos.y()), 1)
             self._main_window.uiDrawRectangleAction.setChecked(False)
             self.setCursor(QtCore.Qt.ArrowCursor)
             self._adding_rectangle = False
         elif event.button() == QtCore.Qt.LeftButton and self._adding_ellipse:
             pos = self.mapToScene(event.pos())
-            self.createDrawingItem("ellipse", pos.x(), pos.y(), 1)
+            self.createDrawingItem("ellipse", int(pos.x()), int(pos.y()), 1)
             self._main_window.uiDrawEllipseAction.setChecked(False)
             self.setCursor(QtCore.Qt.ArrowCursor)
             self._adding_ellipse = False
         elif event.button() == QtCore.Qt.LeftButton and self._adding_line:
             pos = self.mapToScene(event.pos())
-            self.createDrawingItem("line", pos.x(), pos.y(), 1)
+            self.createDrawingItem("line", int(pos.x()), int(pos.y()), 1)
             self._main_window.uiDrawLineAction.setChecked(False)
             self.setCursor(QtCore.Qt.ArrowCursor)
             self._adding_line = False

--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -723,8 +723,8 @@ class GraphicsView(QtWidgets.QGraphicsView):
                 integer, ok = QtWidgets.QInputDialog.getInt(self, "Nodes", "Number of nodes:", 2, 1, 100, 1)
                 if ok:
                     for node_number in range(integer):
-                        x = event.pos().x() - (150 / 2) + (node_number % max_nodes_per_line) * offset
-                        y = event.pos().y() - (70 / 2) + (node_number // max_nodes_per_line) * offset
+                        x = int(event.pos().x() - (150 / 2) + (node_number % max_nodes_per_line) * offset)
+                        y = int(event.pos().y() - (70 / 2) + (node_number // max_nodes_per_line) * offset)
                         if self.createNodeFromTemplateId(template_id, QtCore.QPoint(x, y)) is False:
                             event.ignore()
                             break


### PR DESCRIPTION
While shift+dropping devices, QPoint would be called with floats, preventing the insertion of devices.
This is a simple fix like https://github.com/GNS3/gns3-gui/pull/3272
Because these issues have been occurring since python3.10, would it be preferable to look for the root issue?