### PR TITLE
CVE-2007-4559 patch

### DIFF
--- a/gns3/update_manager.py
+++ b/gns3/update_manager.py
@@ -239,4 +239,22 @@ class UpdateManager(QtCore.QObject):
                 for member in members:
                     # Path separator is always / even on windows
                     member.name = member.name.split("/", 1)[1]
-                tar.extractall(path=self._package_directory, members=members)
+                def is_within_directory(directory, target):
+
+                    abs_directory = os.path.abspath(directory)
+                    abs_target = os.path.abspath(target)
+
+                    prefix = os.path.commonprefix([abs_directory, abs_target])
+
+                    return prefix == abs_directory
+
+                def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+
+                    for member in tar.getmembers():
+                        member_path = os.path.join(path, member.name)
+                        if not is_within_directory(path, member_path):
+                            raise Exception("Attempted Path Traversal in Tar File")
+
+                    tar.extractall(path, members, numeric_owner=numeric_owner)
+
+                safe_extract(tar, path=self._package_directory, members=members)


### PR DESCRIPTION
Hello the GNS3 team! I'm the developer of Kaisen Linux, a distribution for network and system administrators.
By default, the gns3-gui software is included. The company Trellix has contributed to my Debian package gns3-gui to add a patch on the CVE-2007-4559. The details here of their contribution: https://github.com/kaisenlinux/gns3-gui/pull/1

I'm transferring their patch to you via this PR so you can integrate it upstream.