### PR TITLE
Add import sys in sudo.py

### DIFF
--- a/gns3/utils/sudo.py
+++ b/gns3/utils/sudo.py
@@ -17,6 +17,7 @@
 
 import shlex
 import subprocess
+import sys
 
 from gns3.qt import QtWidgets
 from gns3.utils.progress_dialog import ProgressDialog


### PR DESCRIPTION
The sys module is missing into the gns3/utils/sudo.py file. Capabilities required for ubridge cannot be set without this module.

Reported from Kaisen Linux (based on Debian trixie (testing)) with Python 3.11.4. GNS3 server, ubridge and dynamips also installed on my computer.