### PR TITLE
Add Keyboard Shortcut (Ctrl+L) for Add Link Tool

### DIFF
--- a/gns3/ui/main_window.ui
+++ b/gns3/ui/main_window.ui
@@ -1152,6 +1152,9 @@ background-none;
    <property name="statusTip">
     <string>Add a link</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
+   </property>
   </action>
   <action name="uiFitInViewAction">
    <property name="text">

--- a/gns3/ui/main_window_ui.py
+++ b/gns3/ui/main_window_ui.py
@@ -707,6 +707,7 @@ class Ui_MainWindow(object):
         self.uiAddLinkAction.setText(_translate("MainWindow", "Add a link"))
         self.uiAddLinkAction.setToolTip(_translate("MainWindow", "Add a link"))
         self.uiAddLinkAction.setStatusTip(_translate("MainWindow", "Add a link"))
+        self.uiAddLinkAction.setShortcut(_translate("MainWindow", "Ctrl+L"))
         self.uiFitInViewAction.setText(_translate("MainWindow", "Fit in view"))
         self.uiFitInViewAction.setShortcut(_translate("MainWindow", "Ctrl+1"))
         self.uiActionFullscreen.setText(_translate("MainWindow", "Fullscreen"))


### PR DESCRIPTION
### Description:
This PR introduces a new keyboard shortcut, **Ctrl+L**, for the "Add Link" tool in the GNS3 GUI. The shortcut provides faster access to the link creation functionality, improving workflow efficiency for users frequently adding links between devices.

#### Changes made:
- Added **Ctrl+L** as a keyboard shortcut to activate the "Add Link" tool
  
#### Testing:
- Verified the shortcut works as expected on NixOS 24.05

This small enhancement aims to streamline the process of linking devices in GNS3 by providing a direct, convenient shortcut
