### PR TITLE
Add CSS Grid Color Customization Support

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -74,6 +74,10 @@ class GraphicsView(QtWidgets.QGraphicsView):
     :param parent: parent widget
     """
 
+    # Class-level constants for default colors
+    DEFAULT_DRAWING_GRID_COLOR = QtGui.QColor(208, 208, 208)  # #D0D0D0
+    DEFAULT_NODE_GRID_COLOR = QtGui.QColor(190, 190, 190)     # #BEBEBE
+
     def __init__(self, parent):
 
         # Our parent is the central widget which parent is the main window.
@@ -92,6 +96,8 @@ class GraphicsView(QtWidgets.QGraphicsView):
         self._dragging = False
         self._grid_size = 75
         self._drawing_grid_size = 25
+        self._drawing_grid_color = self.DEFAULT_DRAWING_GRID_COLOR
+        self._node_grid_color = self.DEFAULT_NODE_GRID_COLOR
         self._last_mouse_position = None
         self._topology = Topology.instance()
         self._background_warning_msgbox = QtWidgets.QErrorMessage(self)
@@ -1659,11 +1665,39 @@ class GraphicsView(QtWidgets.QGraphicsView):
         self._topology.addDrawing(item)
         return item
 
+    @QtCore.Property(QtGui.QColor)
+    def drawingGridColor(self):
+        """Returns the drawing grid color"""
+        return self._drawing_grid_color
+
+    @drawingGridColor.setter
+    def drawingGridColor(self, color):
+        """Sets the drawing grid color"""
+        self._drawing_grid_color = color
+        self.viewport().update()
+
+    @QtCore.Property(QtGui.QColor)
+    def nodeGridColor(self):
+        """Returns the node grid color"""
+        return self._node_grid_color
+
+    @nodeGridColor.setter
+    def nodeGridColor(self, color):
+        """Sets the node grid color"""
+        self._node_grid_color = color
+        self.viewport().update()
+
+    def resetGridColors(self):
+        """Reset grid colors to defaults"""
+        self._drawing_grid_color = self.DEFAULT_DRAWING_GRID_COLOR
+        self._node_grid_color = self.DEFAULT_NODE_GRID_COLOR
+        self.viewport().update()
+
     def drawBackground(self, painter, rect):
         super().drawBackground(painter, rect)
         if self._main_window.uiShowGridAction.isChecked():
-            grids = [(self.drawingGridSize(), QtGui.QColor(208, 208, 208)),
-                     (self.nodeGridSize(), QtGui.QColor(190, 190, 190))]
+            grids = [(self.drawingGridSize(), self._drawing_grid_color),
+                     (self.nodeGridSize(), self._node_grid_color)]
             painter.save()
             for (grid, colour) in grids:
                 if not grid:

--- a/gns3/style.py
+++ b/gns3/style.py
@@ -47,6 +47,10 @@ class Style:
         Sets the legacy GUI style.
         """
 
+        graphics_view = self._mw.uiGraphicsView
+        if hasattr(graphics_view, 'resetGridColors'):
+            graphics_view.resetGridColors()
+
         self._mw.setStyleSheet("")
         self._mw.uiNewProjectAction.setIcon(QtGui.QIcon(":/icons/new-project.svg"))
         self._mw.uiOpenProjectAction.setIcon(QtGui.QIcon(":/icons/open.svg"))
@@ -98,6 +102,10 @@ class Style:
         """
         Sets the classic GUI style.
         """
+
+        graphics_view = self._mw.uiGraphicsView
+        if hasattr(graphics_view, 'resetGridColors'):
+            graphics_view.resetGridColors()
 
         self._mw.setStyleSheet("")
         self._mw.uiNewProjectAction.setIcon(self._getStyleIcon(":/classic_icons/new-project.svg", ":/classic_icons/new-project-hover.svg"))
@@ -154,6 +162,10 @@ class Style:
         """
         Sets the charcoal GUI style.
         """
+
+        graphics_view = self._mw.uiGraphicsView
+        if hasattr(graphics_view, 'resetGridColors'):
+            graphics_view.resetGridColors()
 
         style_file = QtCore.QFile(":/styles/charcoal.css")
         style_file.open(QtCore.QFile.ReadOnly)


### PR DESCRIPTION
# Apply Grid Color via CSS Property

Adds ability to customize grid colors through CSS by exposing grid colors as Qt properties. Grid colors can now be styled via theme CSS files using:

``` css
QGraphicsView {
  qproperty-drawingGridColor: #someColor;  /* Controls finer grid lines */
  qproperty-nodeGridColor: #someColor;     /* Controls major grid lines */
}
```

If these properties are not defined in a theme's CSS, the grid colors fall back to their original default values. Grid colors are automatically reset when switching themes to ensure proper fallback behavior.

### Changes:
- Added Qt property getters/setters for grid colors in GraphicsView
- Added resetGridColors() method to handle theme changes  
- Modified Style class to reset grid colors when switching themes
- No changes to default behavior when CSS properties aren't specified
- Maintains original default grid colors (light gray #D0D0D0 for drawing grid, slightly darker #BEBEBE for node grid)

Implementation ensures seamless integration with GNS3's existing theme system while providing new customization options through CSS.

### Testing:
- Tested default theme behavior (maintains original colors)
- Tested custom theme CSS color application
- Verified proper color reset when switching between themes
- Confirmed compatibility with existing grid functionality