### PR TITLE
"console connect to all nodes" is now case-insensitively

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -1137,7 +1137,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
         delay = self._main_window.settings()["delay_console_all"]
         counter = 0
-        for name in sorted(nodes.keys()):
+        for name in sorted(nodes.keys(), key=str.casefold):
             node = nodes[name]
             callback = qpartial(self.consoleToNode, node)
             self._main_window.run_later(counter, callback)
@@ -1216,7 +1216,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
         delay = self._main_window.settings()["delay_console_all"]
         counter = 0
-        for name in sorted(nodes.keys()):
+        for name in sorted(nodes.keys(), key=str.casefold):
             node = nodes[name]
             callback = qpartial(self.consoleToNode, node, aux=True)
             self._main_window.run_later(counter, callback)


### PR DESCRIPTION
Hi

Clicking the "console connect to all nodes" opens all consoles in name order with case-insensitively

Example : 
If 4 nodes have name "a", "z", "A", "Z"

Before, GNS3 opens the console of "A", "Z", "a", "z"
Now, GNS3 opens the console of "A", "a", "Z", "z"

( Why is the "DHCP" console not close to "dns"? )

ChatGPT : Use `sorted(nodes.keys(), key=str.casefold)` instead of simple sorted() to ensure case-insensitive ordering. Improves UX by merging uppercase and lowercase entries seamlessly. Python 3.11+ recommended approach.