### PR TITLE
settings.py: add OpenBSD packet capture command

### DIFF
--- a/gns3/settings.py
+++ b/gns3/settings.py
@@ -257,6 +257,11 @@ elif sys.platform.startswith("freebsd"):
     # FreeBSD
     PRECONFIGURED_PACKET_CAPTURE_READER_COMMANDS = {WIRESHARK_NORMAL_CAPTURE: 'wireshark {pcap_file} --capture-comment "{project} {link_description}"',
                                                     WIRESHARK_LIVE_TRAFFIC_CAPTURE: 'gtail -f -c +0b {pcap_file} | wireshark --capture-comment "{project} {link_description}" -o "gui.window_title:{link_description}" -k -i -'}
+
+elif sys.platform.startswith("openbsd"):
+    # OpenBSD
+    PRECONFIGURED_PACKET_CAPTURE_READER_COMMANDS = {WIRESHARK_NORMAL_CAPTURE: 'wireshark {pcap_file} --capture-comment "{project} {link_description}"',
+                                                    WIRESHARK_LIVE_TRAFFIC_CAPTURE: 'tail -f -c +0 {pcap_file} | wireshark --capture-comment "{project} {link_description}" -o "gui.window_title:{link_description}" -k -i -'}
 else:
     PRECONFIGURED_PACKET_CAPTURE_READER_COMMANDS = {WIRESHARK_NORMAL_CAPTURE: 'wireshark {pcap_file} --capture-comment "{project} {link_description}"',
                                                     WIRESHARK_LIVE_TRAFFIC_CAPTURE: 'tail -f -c +0b {pcap_file} | wireshark --capture-comment "{project} {link_description}" -o "gui.window_title:{link_description}" -k -i -'}


### PR DESCRIPTION
hello.

default packet capture command doesn't work in OpenBSD, since `tail` implemention of OpenBSD doesn't support `+0b` notion used here (it however defaults to bytes and not characters).

while we could use `gtail` like FreeBSD, this adds another dependcy to the system which could already done in the base, so i avoided it.

thanks in advance. :-)