### PR TITLE
Add XDG Config Home support

### DIFF
--- a/gns3/dialogs/profile_select.py
+++ b/gns3/dialogs/profile_select.py
@@ -53,6 +53,9 @@ class ProfileSelectDialog(QtWidgets.QDialog, Ui_ProfileSelectDialog):
         if sys.platform.startswith("win"):
             appdata = os.path.expandvars("%APPDATA%")
             path = os.path.join(appdata, "GNS3", version)
+        elif os.path.expandvars("$XDG_CONFIG_HOME"):
+            xdg_config = os.path.expandvars("$XDG_CONFIG_HOME")
+            path = os.path.join(xdg_config, "GNS3", version)
         else:
             home = os.path.expanduser("~")
             path = os.path.join(home, ".config", "GNS3", version)

--- a/gns3/local_config.py
+++ b/gns3/local_config.py
@@ -92,6 +92,9 @@ class LocalConfig(QtCore.QObject):
 
                 if sys.platform.startswith("win"):
                     old_config_path = os.path.join(os.path.expandvars("%APPDATA%"), "GNS3", filename)
+                elif os.path.expandvars("$XDG_CONFIG_HOME"):
+                    xdg_config = os.path.expandvars("$XDG_CONFIG_HOME")
+                    old_config_path = os.path.join(xdg_config, "GNS3", filename)
                 else:
                     old_config_path = os.path.join(os.path.expanduser("~"), ".config", "GNS3", filename)
 
@@ -142,6 +145,9 @@ class LocalConfig(QtCore.QObject):
         if sys.platform.startswith("win"):
             appdata = os.path.expandvars("%APPDATA%")
             path = os.path.join(appdata, "GNS3", version)
+        elif os.path.expandvars("$XDG_CONFIG_HOME"):
+            xdg_config = os.path.expandvars("$XDG_CONFIG_HOME")
+            path = os.path.join(xdg_config, "GNS3", version)
         else:
             home = os.path.expanduser("~")
             path = os.path.join(home, ".config", "GNS3", version)


### PR DESCRIPTION
Adds support for xdg config home, useful in cases where ~/.config isn't the valid path (flatpak)
