### PR TITLE
Fixing tab name in MobaXterm

### DIFF
--- a/gns3/settings.py
+++ b/gns3/settings.py
@@ -57,7 +57,7 @@ if sys.platform.startswith("win"):
 
     PRECONFIGURED_TELNET_CONSOLE_COMMANDS = {'Putty (normal standalone version)': 'putty_standalone.exe -telnet {host} {port} -loghost "{name}"',
                                              'KiTTY': r'kitty -title "{name}" telnet://{host} {port}',
-                                             'MobaXterm': r'"{}\Mobatek\MobaXterm Personal Edition\MobaXterm.exe" -newtab "telnet {{host}} {{port}}"'.format(program_files_x86),
+                                             'MobaXterm': r'"{}\Mobatek\MobaXterm Personal Edition\MobaXterm.exe" -newtab "title {{name}} & telnet {{host}} {{port}}"'.format(program_files_x86),
                                              'Royal TS V3': r'{}\code4ward.net\Royal TS V3\RTS3App.exe /connectadhoc:{{host}} /adhoctype:terminal /p:IsTelnetConnection="true" /p:ConnectionType="telnet;Telnet Connection" /p:Port="{{port}}" /p:Name="{{name}}"'.format(program_files),
                                              'Royal TS V5': r'"{}\Royal TS V5\RoyalTS.exe" /protocol:terminal /using:adhoc /uri:"{{host}}" /property:Port="{{port}}" /property:IsTelnetConnection="true" /property:Name="{{name}}"'.format(program_files_x86),
                                              'SuperPutty': r'SuperPutty.exe -telnet "{host} -P {port} -wt \"{name}\""',


### PR DESCRIPTION
with the current default settings in GNS3-gui, when opening a console connection to a QEMU devices it will show the tab name as "/home/mobaxterm", but with the suggested fix will pickup the hostname and name the new tab accordingly, this how the setting should look like ""C:\<path-to-Moba>\MobaXterm.exe" -newtab "title {name} & telnet {host} {port}"" 