### PR TITLE
Fix tests after PyQt6 migration

### DIFF
--- a/tests/items/test_ellipse_item.py
+++ b/tests/items/test_ellipse_item.py
@@ -23,8 +23,8 @@ from gns3.qt import QtGui, QtCore
 
 def test_toSvg(project, controller):
     ellipse = EllipseItem(width=400, height=100, project=project)
-    pen = QtGui.QPen(QtCore.Qt.black, 2, QtCore.Qt.SolidLine, QtCore.Qt.RoundCap, QtCore.Qt.RoundJoin)
-    pen.setStyle(QtCore.Qt.DashLine)
+    pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 2, QtCore.Qt.PenStyle.SolidLine, QtCore.Qt.PenCapStyle.RoundCap, QtCore.Qt.PenJoinStyle.RoundJoin)
+    pen.setStyle(QtCore.Qt.PenStyle.DashLine)
     ellipse.setPen(pen)
     svg = ET.fromstring(ellipse.toSvg())
     assert float(svg.get("width")) ==  400.0

--- a/tests/items/test_label_item.py
+++ b/tests/items/test_label_item.py
@@ -32,7 +32,7 @@ def test_dump():
     font.setUnderline(True)
     font.setStrikeOut(True)
     label.setFont(font)
-    label.setDefaultTextColor(QtCore.Qt.red)
+    label.setDefaultTextColor(QtCore.Qt.GlobalColor.red)
 
     assert label.dump() == {
         "text": "Test",
@@ -54,7 +54,7 @@ def test_setStyle():
     font.setUnderline(True)
     font.setStrikeOut(False)
     label.setFont(font)
-    label.setDefaultTextColor(QtCore.Qt.red)
+    label.setDefaultTextColor(QtCore.Qt.GlobalColor.red)
 
     style = label.dump()["style"]
     label2 = LabelItem()
@@ -65,4 +65,4 @@ def test_setStyle():
     assert label2.font().bold()
     assert label2.font().strikeOut() is False
     assert label2.font().underline()
-    assert label2.defaultTextColor() == QtCore.Qt.red
+    assert label2.defaultTextColor() == QtCore.Qt.GlobalColor.red

--- a/tests/items/test_line_item.py
+++ b/tests/items/test_line_item.py
@@ -23,8 +23,8 @@ from gns3.qt import QtGui, QtCore
 
 def test_toSvg(project, controller):
     line = LineItem(dst=QtCore.QPointF(400, 280), project=project)
-    pen = QtGui.QPen(QtCore.Qt.black, 2, QtCore.Qt.SolidLine, QtCore.Qt.RoundCap, QtCore.Qt.RoundJoin)
-    pen.setStyle(QtCore.Qt.DashLine)
+    pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 2, QtCore.Qt.PenStyle.SolidLine, QtCore.Qt.PenCapStyle.RoundCap, QtCore.Qt.PenJoinStyle.RoundJoin)
+    pen.setStyle(QtCore.Qt.PenStyle.DashLine)
     line.setPen(pen)
     svg = ET.fromstring(line.toSvg())
     assert float(svg.get("width")) == 400.0
@@ -42,8 +42,8 @@ def test_toSvg(project, controller):
 
 def test_toSvg_negative_y(project, controller):
     line = LineItem(dst=QtCore.QPointF(400, -280), project=project)
-    pen = QtGui.QPen(QtCore.Qt.black, 2, QtCore.Qt.SolidLine, QtCore.Qt.RoundCap, QtCore.Qt.RoundJoin)
-    pen.setStyle(QtCore.Qt.DashLine)
+    pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 2, QtCore.Qt.PenStyle.SolidLine, QtCore.Qt.PenCapStyle.RoundCap, QtCore.Qt.PenJoinStyle.RoundJoin)
+    pen.setStyle(QtCore.Qt.PenStyle.DashLine)
     line.setPen(pen)
     svg = ET.fromstring(line.toSvg())
     assert float(svg.get("width")) == 400.0
@@ -69,7 +69,7 @@ def test_fromSvg(project, controller):
     assert line.line().x2() == 250
     assert line.line().y2() == 150
     assert hex(line.pen().color().rgba()) == "0xff0000ff"
-    assert line.pen().style() == QtCore.Qt.DashDotLine
+    assert line.pen().style() == QtCore.Qt.PenStyle.DashDotLine
     assert line.pos().x() == 50
     assert line.pos().y() == 84
 
@@ -84,7 +84,7 @@ def test_fromSvg_top_direction(project, controller):
     assert line.line().x2() == 250
     assert line.line().y2() == 0
     assert hex(line.pen().color().rgba()) == "0xff0000ff"
-    assert line.pen().style() == QtCore.Qt.DashDotLine
+    assert line.pen().style() == QtCore.Qt.PenStyle.DashDotLine
     assert line.pos().x() == 50
     assert line.pos().y() == 84
 
@@ -92,7 +92,7 @@ def test_fromSvg_top_direction(project, controller):
 def test_fromSvg_solid_stroke(project, controller):
     line = LineItem(project=project)
     line.fromSvg('<svg height="150" width="250"><line x1="0" y1="0" x2="250" y2="150" stroke-width="5" stroke="#0000ff" /></svg>')
-    assert line.pen().style() == QtCore.Qt.SolidLine
+    assert line.pen().style() == QtCore.Qt.PenStyle.SolidLine
 
 
 def test_fromEmptySvg(project, controller):

--- a/tests/items/test_rectangle_item.py
+++ b/tests/items/test_rectangle_item.py
@@ -23,8 +23,8 @@ from gns3.qt import QtGui, QtCore
 
 def test_toSvg(project, controller):
     rect = RectangleItem(width=400, height=280, project=project)
-    pen = QtGui.QPen(QtCore.Qt.black, 2, QtCore.Qt.SolidLine, QtCore.Qt.RoundCap, QtCore.Qt.RoundJoin)
-    pen.setStyle(QtCore.Qt.DashLine)
+    pen = QtGui.QPen(QtCore.Qt.GlobalColor.black, 2, QtCore.Qt.PenStyle.SolidLine, QtCore.Qt.PenCapStyle.RoundCap, QtCore.Qt.PenJoinStyle.RoundJoin)
+    pen.setStyle(QtCore.Qt.PenStyle.DashLine)
     rect.setPen(pen)
     svg = ET.fromstring(rect.toSvg())
     assert float(svg.get("width")) == 400.0
@@ -49,13 +49,13 @@ def test_fromSvg(project, controller):
     assert rect.pen().width() == 5
     assert hex(rect.pen().color().rgba()) == "0xff0000ff"
     assert hex(rect.brush().color().rgba()) == "0x80ff00ff"
-    assert rect.pen().style() == QtCore.Qt.DashDotLine
+    assert rect.pen().style() == QtCore.Qt.PenStyle.DashDotLine
 
 
 def test_fromSvg_solid_stroke(project, controller):
     rect = RectangleItem(project=project)
     rect.fromSvg('<svg height="150" width="250"><rect height="150" stroke-width="5" stroke="#0000ff" fill="#ff00ff" width="150" /></svg>')
-    assert rect.pen().style() == QtCore.Qt.SolidLine
+    assert rect.pen().style() == QtCore.Qt.PenStyle.SolidLine
 
 
 def test_fromEmptySvg(project, controller):

--- a/tests/items/test_text_item.py
+++ b/tests/items/test_text_item.py
@@ -46,7 +46,7 @@ def test_fromSvg(project, controller):
     font.setItalic(True)
     font.setStrikeOut(True)
     text.setFont(font)
-    text.setDefaultTextColor(QtCore.Qt.red)
+    text.setDefaultTextColor(QtCore.Qt.GlobalColor.red)
     text.setPlainText("Hello")
 
     text2 = TextItem(project=project)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -35,7 +35,7 @@ def network_manager(response):
 def response():
     response = unittest.mock.MagicMock()
     type(response).finished = unittest.mock.PropertyMock(return_value=FakeQtSignal())
-    response.error.return_value = QtNetwork.QNetworkReply.NoError
+    response.error.return_value = QtNetwork.QNetworkReply.NetworkError.NoError
     response.attribute.return_value = 200
     response.header.return_value = "application/json"
     return response
@@ -155,7 +155,7 @@ def test_post_not_connected_connection_failed(http_client, http_request, network
 
     # Trigger the completion of /version
     response.finished.emit()
-    response.error.emit(QtNetwork.QNetworkReply.ConnectionRefusedError)
+    response.error.emit(QtNetwork.QNetworkReply.NetworkError.ConnectionRefusedError)
 
     assert callback.called
 
@@ -178,7 +178,7 @@ def test_post_not_connected_connection_failed_retry(http_client, http_request, n
 
     # Trigger the completion of /version
     response.finished.emit()
-    response.error.emit(QtNetwork.QNetworkReply.ConnectionRefusedError)
+    response.error.emit(QtNetwork.QNetworkReply.NetworkError.ConnectionRefusedError)
 
     assert http_client._retryConnection.called
     assert not callback.called
@@ -206,7 +206,7 @@ def test_readyReadySlot(http_client):
     response = unittest.mock.MagicMock()
     server = unittest.mock.MagicMock()
     response.header.return_value = "application/json"
-    response.error.return_value = QtNetwork.QNetworkReply.NoError
+    response.error.return_value = QtNetwork.QNetworkReply.NetworkError.NoError
     response.attribute.return_value = 200
 
     response.readAll.return_value = b'{"action": "ping"}'
@@ -224,7 +224,7 @@ def test_readyReadySlotHTTPError(http_client):
     response = unittest.mock.MagicMock()
     server = unittest.mock.MagicMock()
     response.header.return_value = "application/json"
-    response.error.return_value = QtNetwork.QNetworkReply.NoError
+    response.error.return_value = QtNetwork.QNetworkReply.NetworkError.NoError
     response.attribute.return_value = 404
 
     http_client._readyReadySlot(response, callback, {"query_id": "bla"}, server)
@@ -238,7 +238,7 @@ def test_readyReadySlotConnectionRefusedError(http_client):
     response = unittest.mock.MagicMock()
     server = unittest.mock.MagicMock()
     response.header.return_value = "application/json"
-    response.error.return_value = QtNetwork.QNetworkReply.ConnectionRefusedError
+    response.error.return_value = QtNetwork.QNetworkReply.NetworkError.ConnectionRefusedError
     response.attribute.return_value = 200
 
     http_client._readyReadySlot(response, callback, {"query_id": "bla"}, server)
@@ -255,7 +255,7 @@ def test_readyReadySlotPartialJSON(http_client):
     server = unittest.mock.MagicMock()
     response.header.return_value = "application/json"
     response.readAll.return_value = b'{"action": "ping"'
-    response.error.return_value = QtNetwork.QNetworkReply.NoError
+    response.error.return_value = QtNetwork.QNetworkReply.NetworkError.NoError
     response.attribute.return_value = 200
 
     http_client._readyReadySlot(response, callback, {"query_id": "bla"}, server)
@@ -276,7 +276,7 @@ def test_readyReadySlotPartialBytes(http_client):
     server = unittest.mock.MagicMock()
     response.header.return_value = "application/octet-stream"
     response.readAll.return_value = b'hello'
-    response.error.return_value = QtNetwork.QNetworkReply.NoError
+    response.error.return_value = QtNetwork.QNetworkReply.NetworkError.NoError
     response.attribute.return_value = 200
 
     http_client._readyReadySlot(response, callback, {"query_id": "bla"}, server)


### PR DESCRIPTION
Update failing test files to use PyQt6 new enums.

Issue detected while upgrading gns3-gui to 2.2.56.1 on NixOS: https://github.com/NixOS/nixpkgs/pull/487038
