### PR TITLE
Fix vmrun detection for native 64-bit VMware Workstation (26H1+)

### DIFF
--- a/gns3/modules/vmware/__init__.py
+++ b/gns3/modules/vmware/__init__.py
@@ -78,9 +78,14 @@ class VMware(Module):
             vmrun_path = shutil.which("vmrun")
             if vmrun_path is None:
                 # look for vmrun.exe using the VMware Workstation directory listed in the registry
-                vmrun_path = VMware._findVmrunRegistry(r"SOFTWARE\Wow6432Node\VMware, Inc.\VMware Workstation")
+                # (native 64-bit key first; VMware Workstation 26H1+ dropped the 32-bit build)
+                vmrun_path = VMware._findVmrunRegistry(r"SOFTWARE\VMware, Inc.\VMware Workstation")
+                if vmrun_path is None:
+                    vmrun_path = VMware._findVmrunRegistry(r"SOFTWARE\Wow6432Node\VMware, Inc.\VMware Workstation")
                 if vmrun_path is None:
                     # look for vmrun.exe using the VIX directory listed in the registry
+                    vmrun_path = VMware._findVmrunRegistry(r"SOFTWARE\VMware, Inc.\VMware VIX")
+                if vmrun_path is None:
                     vmrun_path = VMware._findVmrunRegistry(r"SOFTWARE\Wow6432Node\VMware, Inc.\VMware VIX")
         elif sys.platform.startswith("darwin"):
             vmware_fusion_vmrun_path = None


### PR DESCRIPTION
VMware Workstation 26H1 dropped the 32-bit build and is now native 64-bit only. Its install path is written to the native 64-bit registry view (SOFTWARE\VMware, Inc.\VMware Workstation) instead of the WOW64 view (SOFTWARE\Wow6432Node\VMware, Inc.\...) that findVmrun() previously checked exclusively.

This meant GNS3 could no longer auto-detect vmrun.exe on hosts running VMware Workstation 26H1+, throwing "VMware vmrun tool could not be found" even though it was installed, requiring users to manually set the path in Preferences.

This adds a check of the native 64-bit registry key before falling back to the Wow6432Node key, for both the Workstation and VIX lookups. No other behavior changes.

Fixes #3845