### PR TITLE
Remove deleted project from recent projects immediately

### DIFF
--- a/gns3/project.py
+++ b/gns3/project.py
@@ -600,7 +600,15 @@ class Project(QtCore.QObject):
         Delete the project from all servers
         """
         self.project_about_to_close_signal.emit()
-        Controller.instance().delete("/projects/{project_id}".format(project_id=self._id), self._projectClosedCallback, progressText="Delete the project")
+        Controller.instance().delete("/projects/{project_id}".format(project_id=self._id), self._projectDestroyedCallback, progressText="Delete the project")
+
+    def _projectDestroyedCallback(self, result, error=False, server=None, **kwargs):
+        self._projectClosedCallback(result, error=error, server=server, **kwargs)
+        if not error or ("status" in result and result["status"] == 404):
+            # Refresh the controller's project list so a deleted project disappears
+            # immediately from menus such as "recent projects" instead of only
+            # after restarting the GUI.
+            Controller.instance().refreshProjectList()
 
     def _projectClosedCallback(self, result, error=False, server=None, **kwargs):
 


### PR DESCRIPTION
Project.destroy() (used only when a project is actually deleted, not when it's simply closed) issued a raw DELETE request and never refreshed the controller's cached project list. Since "recent projects" filtering in the GUI checks each entry against that cached list, a deleted project stayed visible under Recent Projects - and could still be clicked, which threw a GUI freeze - until the app was restarted and the list was freshly refetched.

destroy() now uses its own callback, _projectDestroyedCallback, which does everything the previous callback did and additionally calls Controller.refreshProjectList() on success. This matches the same pattern already used by Controller.deleteProject() elsewhere in the codebase. The ordinary project-close path (close()) is untouched.

Fixes #3815